### PR TITLE
Temporarily disable python 3.13 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           - '3.10'
           - '3.11'
           - '3.12'
-          - '3.13'
+          # - '3.13' # Temporarily disabled due to numpy not having pre-built wheels
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Numpy does not have pre-built wheels for python 3.13 yet so running the CI workflow job for that version takes 5-10x the time of other versions.