### PR TITLE
Correct install instructions, drop python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
           - '3.10'
           - '3.11'
           - '3.12'
-          - '3.13'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -10,12 +10,6 @@ To install vaxflux using pip, run the following command in your terminal:
 
 .. code-block:: shell
 
-    pip install git+git://github.com/ACCIDDA/vaxflux.git
-
-Alternatively, if you would prefer to install the package of https you can use:
-
-.. code-block:: shell
-
     pip install git+https://github.com/ACCIDDA/vaxflux.git
 
 Using `conda`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Flexible bayesian models for seasonal vaccine uptake."
 readme = "README.md"
 license = { text = "MIT" }
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.13"
 dependencies = [
     "numpy>=1.17.0,<2",
     "pymc>5.16.2",


### PR DESCRIPTION
* Fix incorrect instructions for installing from GitHub directly with `pip`,
* Drop python 3.13, runs into errors when installing with `pip` that requires further investigating.