### PR TITLE
Split `docs` job out of `ci` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
@@ -21,8 +18,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Setup pandoc for docs
-        uses: r-lib/actions/setup-pandoc@v2
       - name: Setup uv with python ${{ matrix.python-version }}
         uses: astral-sh/setup-uv@v6
         with:
@@ -31,5 +26,27 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Run Checks
         run: make ci
+        env:
+          UV_PYTHON_VERSION: ${{ matrix.python-version }}
+  docs:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - '3.12'
+    needs: ci
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup pandoc for docs
+        uses: r-lib/actions/setup-pandoc@v2
+      - name: Setup uv with python ${{ matrix.python-version }}
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: 'pyproject.toml'
+          python-version: ${{ matrix.python-version }}
+      - name: Build docs
+        run: make docs
         env:
           UV_PYTHON_VERSION: ${{ matrix.python-version }}

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ clean:
 	uv sync --all-extras
 	uv pip install --editable .
 
-rstcheck:
+rstcheck: .venv
 	$(UV_PROJECT_ENVIRONMENT)/bin/rstcheck --warn-unknown-settings --recursive docs/
 
 docs/_build: .venv
@@ -71,4 +71,3 @@ ci: .venv
 	$(UV_PROJECT_ENVIRONMENT)/bin/ruff check --no-fix
 	$(UV_PROJECT_ENVIRONMENT)/bin/mypy --strict .
 	$(UV_PROJECT_ENVIRONMENT)/bin/pytest --doctest-modules --exitfirst
-	@$(MAKE) docs


### PR DESCRIPTION
Split the `docs` job out of the `ci` job and only run with python 3.12. The documentation should be independent of version so it serves no value to build/check it multiple times with different python versions. Also allows for an early exit if the CI jobs encounter an issue. While the docs target was removed from the ci target in the make file, the all target still contains it for rapid developer feedback.