### PR TITLE
Add workflow to deploy docs to GitHub pages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,13 @@ name: CI
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: 'read'
+
 jobs:
   ci:
     name: 'ci'

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -1,0 +1,80 @@
+---
+name: 'GitHub Pages Deploy'
+
+'on':
+  push:
+    branches:
+      - 'main'
+  release:
+    types:
+      - 'published'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: 'read'
+
+jobs:
+  deploy:
+    name: 'deploy'
+    runs-on: 'ubuntu-latest'
+    strategy:
+      matrix:
+        python-version:
+          - '3.12'
+    permissions:
+      contents: 'write' # Needed to push to gh-pages
+    steps:
+      - name: 'checkout repository'
+        uses: 'actions/checkout@v5'
+        with:
+          ref: 'main'
+          persist-credentials: false
+      - name: 'setup just'
+        uses: 'extractions/setup-just@v3'
+      - name: 'setup uv with python ${{ matrix.python-version }}'
+        uses: 'astral-sh/setup-uv@v7'
+        with:
+          enable-cache: true
+          cache-dependency-glob: 'pyproject.toml'
+          python-version: '${{ matrix.python-version }}'
+      - name: 'fetch gh-pages branch'
+        run: |
+          git fetch origin gh-pages:gh-pages --depth=1
+          git config --global user.name "${ACTOR}"
+          git config --global user.email "${ACTOR}@users.noreply.github.com"
+        env:
+          ACTOR: '${{ github.actor }}'
+      - name: 'extract version'
+        id: extract-version
+        run: |
+          cat > version.py << EOF
+          import tomllib
+          with open('pyproject.toml', 'rb') as f:
+              data = tomllib.load(f)
+          version = data['project']['version']
+          version = '.'.join(version.split('.')[:2])
+          print(f"version={version}")
+          EOF
+          uv run -qq python version.py >> $GITHUB_OUTPUT
+          rm version.py
+      - name: 'build docs'
+        run: 'just docs'
+      - name: 'Deploy to GitHub Pages'
+        run: |
+          uv run mike set-default latest
+          if [ "${EVENT_NAME}" == "release" ] || [[ $VERSION == 0* ]]; then
+            ALIAS=latest
+          else
+            ALIAS=dev
+          fi
+          uv run mike deploy \
+            --push --update-aliases \
+            ${VERSION} ${ALIAS}
+        env:
+          EVENT_NAME: '${{ github.event_name }}'
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          VERSION: '${{ steps.extract-version.outputs.version }}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Added:
 - Added a `CONTRIBUTING.md` document that is also synced with the documentation
   site outlining how to get started as a developer and contribute, see
   [#75](https://github.com/ACCIDDA/vaxflux/issues/75).
+- Added versioned documentation site hosted by GitHub pages at
+  [accidda.github.io/vaxflux/](https://accidda.github.io/vaxflux/), see
+  [#62](https://github.com/ACCIDDA/vaxflux/issues/62).
 
 Changed:
 


### PR DESCRIPTION
Added the `gh-pages.yaml` workflow, modeled after
https://github.com/ACCIDDA/flepimop2/blob/main/.github/workflows/gh-pages.yaml, to automatically build and deploy the documentation on update to `main` or when a release is created.

Closes #62.