### PR TITLE
Fix GitHub pages deployment

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -32,7 +32,6 @@ jobs:
         uses: 'actions/checkout@v5'
         with:
           ref: 'main'
-          persist-credentials: false
       - name: 'setup just'
         uses: 'extractions/setup-just@v3'
       - name: 'setup uv with python ${{ matrix.python-version }}'


### PR DESCRIPTION
Fixed bug in GitHub pages deployment where the credentials not being
persisted in the `actions/checkout` step caused an authentication
failure when trying to push in later steps. No major changes.

Failed: https://github.com/ACCIDDA/vaxflux/actions/runs/19507692705
Success: https://github.com/ACCIDDA/vaxflux/actions/runs/19514079369