### PR TITLE
Convert `uv` dev dep group to a 'dependency-group'

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,8 @@ jobs:
         run: |
           git fetch origin main:main
           GIT_LOG=$(git log main..HEAD --pretty=format:"%s %b")
-          if echo "$GIT_LOG" | grep -iq "no major changes"; then
+          SKIP_REGEX="no[[:space:]]+major[[:space:]]+changes"
+          if echo "$GIT_LOG" | tr '\n' ' ' | grep -Eiq "$SKIP_REGEX"; then
             echo "Bypassing changelog check: 'no major changes' found in commit history"
             exit 0
           fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,26 @@ dependencies = [
     "blackjax>=1.2.5",
 ]
 
+[dependency-groups]
+dev = [
+    "mike>=2.1.3",
+    "mkdocs>=1.6.1",
+    "mkdocs-autorefs>=1.4.3",
+    "mkdocs-material>=9.7.0",
+    "mkdocstrings[python]>=0.30.1",
+    "mypy>=1.14.1",
+    "pandas-stubs>=2.2.3.241126",
+    "pydata-sphinx-theme>=0.16.1",
+    "pytest>=8.3.2",
+    "rstcheck[sphinx]>=6.2.4",
+    "ruamel-yaml>=0.18.16",
+    "ruff>=0.9.4",
+    "scipy-stubs>=1.15.1.0",
+    "sphinx>=8.1.3",
+    "types-requests>=2.32.0.20241016",
+    "yamllint>=1.37.1",
+]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
@@ -34,26 +54,6 @@ demo = [
 testpaths = [
     "src/vaxflux/",
     "tests/",
-]
-
-[tool.uv]
-dev-dependencies = [
-    "mike>=2.1.3",
-    "mkdocs>=1.6.1",
-    "mkdocs-autorefs>=1.4.3",
-    "mkdocs-material>=9.7.0",
-    "mkdocstrings[python]>=0.30.1",
-    "mypy>=1.14.1",
-    "pandas-stubs>=2.2.3.241126",
-    "pydata-sphinx-theme>=0.16.1",
-    "pytest>=8.3.2",
-    "rstcheck[sphinx]>=6.2.4",
-    "ruamel-yaml>=0.18.16",
-    "ruff>=0.9.4",
-    "scipy-stubs>=1.15.1.0",
-    "sphinx>=8.1.3",
-    "types-requests>=2.32.0.20241016",
-    "yamllint>=1.37.1",
 ]
 
 [tool.ruff.format]


### PR DESCRIPTION
Converted 'tool.uv.dev-dependencies' to 'dependency-groups.dev'. No
major changes. Closes #96.