### PR TITLE
Drop python 3.10 support, add 3.13

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,9 +21,9 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.10'
           - '3.11'
           - '3.12'
+          - '3.13'
     steps:
       - name: 'checkout repository'
         uses: 'actions/checkout@v5'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Added:
 - Added versioned documentation site hosted by GitHub pages at
   [accidda.github.io/vaxflux/](https://accidda.github.io/vaxflux/), see
   [#62](https://github.com/ACCIDDA/vaxflux/issues/62).
+- Added support for python 3.13, see
+  [#90](https://github.com/ACCIDDA/vaxflux/issues/90).
 
 Changed:
 
@@ -39,7 +41,8 @@ Deprecated:
 
 Removed:
 
-- ...
+- Dropped support for python 3.10, see
+  [#90](https://github.com/ACCIDDA/vaxflux/issues/90).
 
 Fixed:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Flexible bayesian models for seasonal vaccine uptake."
 readme = "README.md"
 license = { text = "MIT" }
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.11,<3.14"
 dependencies = [
     "numpy>=1.17.0,<2",
     "pymc>5.16.2",
@@ -26,13 +26,10 @@ dev = [
     "mkdocstrings[python]>=0.30.1",
     "mypy>=1.14.1",
     "pandas-stubs>=2.2.3.241126",
-    "pydata-sphinx-theme>=0.16.1",
     "pytest>=8.3.2",
-    "rstcheck[sphinx]>=6.2.4",
     "ruamel-yaml>=0.18.16",
     "ruff>=0.9.4",
     "scipy-stubs>=1.15.1.0",
-    "sphinx>=8.1.3",
     "types-requests>=2.32.0.20241016",
     "yamllint>=1.37.1",
 ]
@@ -98,8 +95,3 @@ max-args = 8  # Default is 5
 [[tool.mypy.overrides]]
 module = ["pymc.*"]
 ignore_missing_imports = true
-
-[tool.rstcheck]
-ignore_directives = [
-    "automodule",
-]

--- a/src/vaxflux/data.py
+++ b/src/vaxflux/data.py
@@ -16,7 +16,7 @@ __all__ = (
 
 import io
 import time
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Literal, TypedDict, cast
 
 import numpy as np
@@ -48,7 +48,7 @@ def get_ncird_weekly_cumulative_vaccination_coverage() -> pd.DataFrame:
         'legend_sort', '95_ci_lower', and '95_ci_upper'.
 
     """  # noqa: E501
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     cache_bust = time.mktime(now.timetuple())
     date = now.strftime("%Y%m%d")
     url = (

--- a/src/vaxflux/uptake.py
+++ b/src/vaxflux/uptake.py
@@ -7,10 +7,9 @@ import copy
 import itertools
 import logging
 import math
-import sys
 from collections.abc import Iterable
 from datetime import timedelta
-from typing import Any, cast
+from typing import Any, Self, cast
 
 import arviz as az
 import pandas as pd
@@ -35,11 +34,6 @@ from vaxflux.interventions import (
     Intervention,
     _check_interventions_and_implementations,
 )
-
-if sys.version_info[:2] >= (3, 11):
-    from typing import Self
-else:
-    Self = Any
 
 
 class SeasonalUptakeModel:


### PR DESCRIPTION
Dropped support for python 3.10 and added support for python 3.13. Also
removed legacy dev dependencies `sphinx`, `rstcheck`, and
`pydata-sphinx-theme`.

Closes #90.