### PR TITLE
Add `VaxfluxModel.add_dates`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Added:
   [accidda.github.io/vaxflux/](https://accidda.github.io/vaxflux/), see
   [#62](https://github.com/ACCIDDA/vaxflux/issues/62).
 - Added `VaxfluxModel` and new `Curve` classes that are based on
-  `jax`/`numpyro`.
+  `jax`/`numpyro`. See [#105](https://github.com/ACCIDDA/vaxflux/issues/105).
 
 Changed:
 

--- a/src/vaxflux/_vaxflux_model.py
+++ b/src/vaxflux/_vaxflux_model.py
@@ -1,6 +1,5 @@
 __all__: list[str] = []
 
-from collections.abc import Sequence
 from typing import Any, Self
 
 import numpyro
@@ -8,7 +7,12 @@ from jax.random import PRNGKey
 from numpyro.infer import MCMC, NUTS
 
 from vaxflux._curves import Curve
-from vaxflux.dates import SeasonRange, _seasons_overlap
+from vaxflux.dates import (
+    DateRange,
+    SeasonRange,
+    _collect_ranges,
+    _validate_ranges,
+)
 
 
 class VaxfluxModel:
@@ -22,8 +26,9 @@ class VaxfluxModel:
         """
         self._curve = curve
         self._seasons: list[SeasonRange] = []
+        self._dates: list[DateRange] = []
 
-    def add_seasons(self, *args: SeasonRange | Sequence[SeasonRange]) -> Self:
+    def add_seasons(self, *args: SeasonRange | list[SeasonRange]) -> Self:
         """
         Add one or more seasons to the model.
 
@@ -81,27 +86,48 @@ class VaxfluxModel:
             TypeError: Arguments must be SeasonRange objects or sequences of SeasonRange objects, got str.
 
         """  # noqa: E501
-        seasons: list[SeasonRange] = []
-        for arg in args:
-            if isinstance(arg, SeasonRange):
-                seasons.append(arg)
-            elif isinstance(arg, Sequence) and not isinstance(arg, (str, bytes)):
-                # Validate that all items in the sequence are SeasonRange objects
-                for item in arg:
-                    if not isinstance(item, SeasonRange):
-                        msg = (
-                            f"All items in a sequence must be SeasonRange objects, "
-                            f"got {type(item).__name__}."
-                        )
-                        raise TypeError(msg)
-                seasons.extend(arg)
-            else:
-                msg = (
-                    f"Arguments must be SeasonRange objects or sequences of "
-                    f"SeasonRange objects, got {type(arg).__name__}."
-                )
-                raise TypeError(msg)
-        self._validate_and_add_seasons(seasons)
+        seasons = _collect_ranges(args, SeasonRange, "SeasonRange")
+        _validate_ranges(seasons, self._seasons)
+        self._seasons.extend(seasons)
+        return self
+
+    def add_dates(self, *args: DateRange | list[DateRange]) -> Self:
+        """
+        Add one or more date ranges to the model.
+
+        Args:
+            *args: One or more `DateRange` objects or sequences of `DateRange` objects.
+
+        Returns:
+            The model instance for method chaining.
+
+        Raises:
+            TypeError: If any argument is not a `DateRange` or a sequence of
+                `DateRange` objects.
+            ValueError: If duplicate date ranges are found.
+            ValueError: If overlapping date ranges are found.
+
+        Examples:
+            >>> from vaxflux._curves import LogisticCurve
+            >>> from vaxflux.dates import DateRange
+            >>> model = VaxfluxModel(curve=LogisticCurve())
+            >>> result = model.add_dates(
+            ...     DateRange(
+            ...         season="2023/2024",
+            ...         start_date="2023-12-01",
+            ...         end_date="2023-12-07",
+            ...         report_date="2023-12-08",
+            ...     )
+            ... )
+            >>> model.add_dates("invalid_argument")
+            Traceback (most recent call last):
+                ...
+            TypeError: Arguments must be DateRange objects or sequences of DateRange objects, got str.
+
+        """  # noqa: E501
+        dates = _collect_ranges(args, DateRange, "DateRange")
+        _validate_ranges(dates, self._dates)
+        self._dates.extend(dates)
         return self
 
     def sample(
@@ -131,58 +157,3 @@ class VaxfluxModel:
 
     def _model(self) -> None:
         raise NotImplementedError
-
-    def _validate_and_add_seasons(self, seasons: list[SeasonRange]) -> None:
-        """Validate and add seasons to the model.
-
-        Args:
-            seasons: List of seasons to validate and add.
-
-        Raises:
-            ValueError: If duplicate season names are found.
-            ValueError: If overlapping date ranges are found.
-        """
-        # Check for duplicate season names within the new seasons
-        new_season_names = [season.season for season in seasons]
-        if len(new_season_names) != len(set(new_season_names)):
-            duplicates = {
-                name for name in new_season_names if new_season_names.count(name) > 1
-            }
-            msg = f"Duplicate season names found in new seasons: {sorted(duplicates)}."
-            raise ValueError(msg)
-
-        # Check for duplicate season names against existing seasons
-        existing_season_names = {season.season for season in self._seasons}
-        conflicting_names = existing_season_names & set(new_season_names)
-        if conflicting_names:
-            msg = (
-                f"Season names already exist in the model: {sorted(conflicting_names)}."
-            )
-            raise ValueError(msg)
-
-        # Check for overlapping date ranges within new seasons
-        for i, season1 in enumerate(seasons):
-            for season2 in seasons[i + 1 :]:
-                if _seasons_overlap(season1, season2):
-                    msg = (
-                        f"Overlapping date ranges found: "
-                        f"'{season1.season}' ({season1.start_date} to "
-                        f"{season1.end_date}) and '{season2.season}' "
-                        f"({season2.start_date} to {season2.end_date})."
-                    )
-                    raise ValueError(msg)
-
-        # Check for overlapping date ranges against existing seasons
-        for existing_season in self._seasons:
-            for new_season in seasons:
-                if _seasons_overlap(existing_season, new_season):
-                    msg = (
-                        f"Overlapping date ranges found: "
-                        f"'{existing_season.season}' ({existing_season.start_date} "
-                        f"to {existing_season.end_date}) and '{new_season.season}' "
-                        f"({new_season.start_date} to {new_season.end_date})."
-                    )
-                    raise ValueError(msg)
-
-        # All validations passed, add the seasons
-        self._seasons.extend(seasons)

--- a/src/vaxflux/dates.py
+++ b/src/vaxflux/dates.py
@@ -3,6 +3,7 @@
 __all__ = ("DateRange", "SeasonRange", "daily_date_ranges")
 
 
+from collections.abc import Sequence
 from datetime import date, datetime, timedelta
 from typing import Final, Literal, NamedTuple, TypeVar
 
@@ -169,6 +170,51 @@ class DateRange(BaseModel):
         return self
 
 
+def _date_ranges_overlap(date_range1: DateRange, date_range2: DateRange) -> bool:
+    """
+    Check if two date ranges have overlapping date ranges.
+
+    Args:
+        date_range1: First date range to check.
+        date_range2: Second date range to check.
+
+    Returns:
+        True if the date ranges overlap, False otherwise.
+
+    Examples:
+        >>> from datetime import date
+        >>> from vaxflux.dates import DateRange, _date_ranges_overlap
+        >>> dr1 = DateRange(
+        ...     season="2023/2024",
+        ...     start_date=date(2023, 12, 1),
+        ...     end_date=date(2023, 12, 7),
+        ...     report_date=date(2023, 12, 8),
+        ... )
+        >>> dr2 = DateRange(
+        ...     season="2023/2024",
+        ...     start_date=date(2023, 12, 8),
+        ...     end_date=date(2023, 12, 14),
+        ...     report_date=date(2023, 12, 15),
+        ... )
+        >>> _date_ranges_overlap(dr1, dr2)
+        False
+        >>> # Overlapping date ranges
+        >>> dr3 = DateRange(
+        ...     season="2023/2024",
+        ...     start_date=date(2023, 12, 5),
+        ...     end_date=date(2023, 12, 10),
+        ...     report_date=date(2023, 12, 11),
+        ... )
+        >>> _date_ranges_overlap(dr1, dr3)
+        True
+
+    """
+    return (
+        date_range1.start_date <= date_range2.end_date
+        and date_range2.start_date <= date_range1.end_date
+    )
+
+
 def _seasons_overlap(season1: SeasonRange, season2: SeasonRange) -> bool:
     """
     Check if two seasons have overlapping date ranges.
@@ -244,6 +290,204 @@ def _seasons_overlap(season1: SeasonRange, season2: SeasonRange) -> bool:
         season1.start_date <= season2.end_date
         and season2.start_date <= season1.end_date
     )
+
+
+Range = TypeVar("Range", bound="DateRange | SeasonRange")
+
+
+def _collect_ranges(
+    args: tuple[Range | Sequence[Range], ...],
+    expected_type: type[Range],
+    type_name: str,
+) -> list[Range]:
+    """Collect and validate range objects from arguments.
+
+    Args:
+        args: Variable arguments that can be range objects or sequences.
+        expected_type: The expected type (SeasonRange or DateRange).
+        type_name: Name of the type for error messages.
+
+    Returns:
+        List of validated range objects.
+
+    Raises:
+        TypeError: If arguments are not of the expected type.
+    """
+    ranges: list[Range] = []
+    for arg in args:
+        if isinstance(arg, expected_type):
+            ranges.append(arg)
+        elif isinstance(arg, Sequence) and not isinstance(arg, (str, bytes)):
+            # Validate that all items in the sequence are of expected type
+            for item in arg:
+                if not isinstance(item, expected_type):
+                    msg = (
+                        f"All items in a sequence must be {type_name} objects, "
+                        f"got {type(item).__name__}."
+                    )
+                    raise TypeError(msg)
+            ranges.extend(arg)
+        else:
+            msg = (
+                f"Arguments must be {type_name} objects or sequences of "
+                f"{type_name} objects, got {type(arg).__name__}."
+            )
+            raise TypeError(msg)
+    return ranges
+
+
+def _validate_ranges(
+    new_ranges: list[Range],
+    existing_ranges: list[Range],
+) -> None:
+    """Validate ranges for duplicates and overlaps.
+
+    For SeasonRange objects, checks for:
+    - Duplicate season names within new ranges
+    - Duplicate season names against existing ranges
+    - Overlapping date ranges
+
+    For DateRange objects, checks for:
+    - Exact duplicate date ranges within new ranges
+    - Exact duplicate date ranges against existing ranges
+    - Overlapping date ranges
+
+    Args:
+        new_ranges: New range objects to validate.
+        existing_ranges: Existing range objects to check against.
+
+    Raises:
+        ValueError: If duplicate or overlapping ranges are found.
+    """
+    if not new_ranges:
+        return
+
+    # Determine type and apply appropriate validations
+    if isinstance(new_ranges[0], SeasonRange):
+        _validate_season_ranges(
+            new_ranges,  # type: ignore[arg-type]
+            existing_ranges,  # type: ignore[arg-type]
+        )
+    else:  # DateRange
+        _validate_date_ranges(
+            new_ranges,  # type: ignore[arg-type]
+            existing_ranges,  # type: ignore[arg-type]
+        )
+
+
+def _validate_season_ranges(
+    new_seasons: list[SeasonRange],
+    existing_seasons: list[SeasonRange],
+) -> None:
+    """Validate season ranges for duplicates and overlaps.
+
+    Args:
+        new_seasons: New season ranges to validate.
+        existing_seasons: Existing season ranges to check against.
+
+    Raises:
+        ValueError: If duplicate season names or overlapping ranges are found.
+    """
+    # Check for duplicate season names within the new seasons
+    new_season_names = [season.season for season in new_seasons]
+    if len(new_season_names) != len(set(new_season_names)):
+        duplicates = {
+            name for name in new_season_names if new_season_names.count(name) > 1
+        }
+        msg = f"Duplicate season names found in new seasons: {sorted(duplicates)}."
+        raise ValueError(msg)
+
+    # Check for duplicate season names against existing seasons
+    existing_season_names = {season.season for season in existing_seasons}
+    conflicting_names = existing_season_names & set(new_season_names)
+    if conflicting_names:
+        msg = f"Season names already exist in the model: {sorted(conflicting_names)}."
+        raise ValueError(msg)
+
+    # Check for overlapping date ranges within new seasons
+    for i, season1 in enumerate(new_seasons):
+        for season2 in new_seasons[i + 1 :]:
+            if _seasons_overlap(season1, season2):
+                msg = (
+                    f"Overlapping date ranges found: "
+                    f"'{season1.season}' ({season1.start_date} to "
+                    f"{season1.end_date}) and '{season2.season}' "
+                    f"({season2.start_date} to {season2.end_date})."
+                )
+                raise ValueError(msg)
+
+    # Check for overlapping date ranges against existing seasons
+    for existing_season in existing_seasons:
+        for new_season in new_seasons:
+            if _seasons_overlap(existing_season, new_season):
+                msg = (
+                    f"Overlapping date ranges found: "
+                    f"'{existing_season.season}' ({existing_season.start_date} "
+                    f"to {existing_season.end_date}) and '{new_season.season}' "
+                    f"({new_season.start_date} to {new_season.end_date})."
+                )
+                raise ValueError(msg)
+
+
+def _validate_date_ranges(  # noqa: C901
+    new_dates: list[DateRange],
+    existing_dates: list[DateRange],
+) -> None:
+    """Validate date ranges for exact duplicates and overlaps.
+
+    Args:
+        new_dates: New date ranges to validate.
+        existing_dates: Existing date ranges to check against.
+
+    Raises:
+        ValueError: If duplicate or overlapping date ranges are found.
+    """
+    # Check for exact duplicates within new dates
+    for i, date1 in enumerate(new_dates):
+        for date2 in new_dates[i + 1 :]:
+            if date1 == date2:
+                msg = (
+                    f"Duplicate date range found: season='{date1.season}', "
+                    f"dates={date1.start_date} to {date1.end_date}, "
+                    f"report={date1.report_date}."
+                )
+                raise ValueError(msg)
+
+    # Check for exact duplicates against existing dates
+    for existing_date in existing_dates:
+        for new_date in new_dates:
+            if existing_date == new_date:
+                msg = (
+                    f"Date range already exists: season='{new_date.season}', "
+                    f"dates={new_date.start_date} to {new_date.end_date}, "
+                    f"report={new_date.report_date}."
+                )
+                raise ValueError(msg)
+
+    # Check for overlapping date ranges within new dates
+    for i, date1 in enumerate(new_dates):
+        for date2 in new_dates[i + 1 :]:
+            if _date_ranges_overlap(date1, date2):
+                msg = (
+                    "Overlapping date ranges found: "
+                    f"'{date1.season}' ({date1.start_date} to {date1.end_date}) "
+                    f"and '{date2.season}' ({date2.start_date} to "
+                    f"{date2.end_date})."
+                )
+                raise ValueError(msg)
+
+    # Check for overlapping date ranges against existing dates
+    for existing_date in existing_dates:
+        for new_date in new_dates:
+            if _date_ranges_overlap(existing_date, new_date):
+                msg = (
+                    f"Overlapping date ranges found: "
+                    f"existing '{existing_date.season}' "
+                    f"({existing_date.start_date} to {existing_date.end_date}) "
+                    f"and new '{new_date.season}' "
+                    f"({new_date.start_date} to {new_date.end_date})."
+                )
+                raise ValueError(msg)
 
 
 def daily_date_ranges(

--- a/tests/vaxflux_model_class/test_add_dates.py
+++ b/tests/vaxflux_model_class/test_add_dates.py
@@ -1,0 +1,447 @@
+"""Unit tests for the `VaxfluxModel.add_dates` method."""
+
+from datetime import date
+
+import pytest
+
+from vaxflux._curves import LogisticCurve
+from vaxflux._vaxflux_model import VaxfluxModel
+from vaxflux.dates import DateRange
+
+
+@pytest.mark.parametrize(
+    ("args_factory", "expected_count"),
+    [
+        # Single date range
+        (
+            lambda: (
+                DateRange(
+                    season="2023/2024",
+                    start_date=date(2023, 12, 1),
+                    end_date=date(2023, 12, 7),
+                    report_date=date(2023, 12, 8),
+                ),
+            ),
+            1,
+        ),
+        # Multiple date ranges as args
+        (
+            lambda: (
+                DateRange(
+                    season="2023/2024",
+                    start_date=date(2023, 12, 1),
+                    end_date=date(2023, 12, 7),
+                    report_date=date(2023, 12, 8),
+                ),
+                DateRange(
+                    season="2023/2024",
+                    start_date=date(2023, 12, 8),
+                    end_date=date(2023, 12, 14),
+                    report_date=date(2023, 12, 15),
+                ),
+                DateRange(
+                    season="2023/2024",
+                    start_date=date(2023, 12, 15),
+                    end_date=date(2023, 12, 21),
+                    report_date=date(2023, 12, 22),
+                ),
+            ),
+            3,
+        ),
+        # List of date ranges
+        (
+            lambda: (
+                [
+                    DateRange(
+                        season="2023/2024",
+                        start_date=date(2023, 12, 1),
+                        end_date=date(2023, 12, 7),
+                        report_date=date(2023, 12, 8),
+                    ),
+                    DateRange(
+                        season="2023/2024",
+                        start_date=date(2023, 12, 8),
+                        end_date=date(2023, 12, 14),
+                        report_date=date(2023, 12, 15),
+                    ),
+                ],
+            ),
+            2,
+        ),
+        # Tuple of date ranges
+        (
+            lambda: (
+                (
+                    DateRange(
+                        season="2023/2024",
+                        start_date=date(2023, 12, 1),
+                        end_date=date(2023, 12, 7),
+                        report_date=date(2023, 12, 8),
+                    ),
+                    DateRange(
+                        season="2023/2024",
+                        start_date=date(2023, 12, 8),
+                        end_date=date(2023, 12, 14),
+                        report_date=date(2023, 12, 15),
+                    ),
+                ),
+            ),
+            2,
+        ),
+        # Mixed args and sequences
+        (
+            lambda: (
+                DateRange(
+                    season="2023/2024",
+                    start_date=date(2023, 12, 1),
+                    end_date=date(2023, 12, 7),
+                    report_date=date(2023, 12, 8),
+                ),
+                [
+                    DateRange(
+                        season="2023/2024",
+                        start_date=date(2023, 12, 8),
+                        end_date=date(2023, 12, 14),
+                        report_date=date(2023, 12, 15),
+                    ),
+                    DateRange(
+                        season="2023/2024",
+                        start_date=date(2023, 12, 15),
+                        end_date=date(2023, 12, 21),
+                        report_date=date(2023, 12, 22),
+                    ),
+                ],
+                DateRange(
+                    season="2023/2024",
+                    start_date=date(2023, 12, 22),
+                    end_date=date(2023, 12, 28),
+                    report_date=date(2023, 12, 29),
+                ),
+            ),
+            4,
+        ),
+        # Empty call
+        (lambda: (), 0),
+        # Empty list
+        (lambda: ([],), 0),
+        # Adjacent date ranges (no overlap) - end date + 1 = next start date
+        (
+            lambda: (
+                DateRange(
+                    season="2023/2024",
+                    start_date=date(2023, 12, 1),
+                    end_date=date(2023, 12, 7),
+                    report_date=date(2023, 12, 8),
+                ),
+                DateRange(
+                    season="2023/2024",
+                    start_date=date(2023, 12, 8),
+                    end_date=date(2023, 12, 14),
+                    report_date=date(2023, 12, 15),
+                ),
+            ),
+            2,
+        ),
+        # Non-overlapping date ranges from different seasons
+        (
+            lambda: (
+                DateRange(
+                    season="2023/2024",
+                    start_date=date(2023, 12, 1),
+                    end_date=date(2023, 12, 7),
+                    report_date=date(2023, 12, 8),
+                ),
+                DateRange(
+                    season="2024/2025",
+                    start_date=date(2024, 12, 1),
+                    end_date=date(2024, 12, 7),
+                    report_date=date(2024, 12, 8),
+                ),
+            ),
+            2,
+        ),
+    ],
+    ids=[
+        "single_date_range",
+        "multiple_date_ranges_as_args",
+        "list_of_date_ranges",
+        "tuple_of_date_ranges",
+        "mixed_args_and_sequences",
+        "empty_call",
+        "empty_list",
+        "adjacent_date_ranges_no_overlap",
+        "different_seasons_non_overlapping",
+    ],
+)
+def test_add_dates_input_variations(args_factory: object, expected_count: int) -> None:
+    """Test adding date ranges with various input patterns."""
+    model = VaxfluxModel(curve=LogisticCurve())
+    args = args_factory()  # type: ignore[operator]
+    result = model.add_dates(*args)
+
+    # Check method chaining works
+    assert result is model
+    # Check expected number of date ranges were added
+    assert len(model._dates) == expected_count
+
+
+def test_add_dates_preserves_existing_dates() -> None:
+    """Test that add_dates preserves previously added date ranges."""
+    model = VaxfluxModel(curve=LogisticCurve())
+    dr1 = DateRange(
+        season="2023/2024",
+        start_date=date(2023, 12, 1),
+        end_date=date(2023, 12, 7),
+        report_date=date(2023, 12, 8),
+    )
+    dr2 = DateRange(
+        season="2023/2024",
+        start_date=date(2023, 12, 8),
+        end_date=date(2023, 12, 14),
+        report_date=date(2023, 12, 15),
+    )
+    dr3 = DateRange(
+        season="2023/2024",
+        start_date=date(2023, 12, 15),
+        end_date=date(2023, 12, 21),
+        report_date=date(2023, 12, 22),
+    )
+
+    model.add_dates(dr1)
+    initial_dates = model._dates.copy()
+
+    model.add_dates(dr2, dr3)
+
+    # Check initial date ranges are still there
+    assert model._dates[0] == initial_dates[0]
+    # Check new date ranges were added
+    assert len(model._dates) == 3
+    assert model._dates[1] == dr2
+    assert model._dates[2] == dr3
+
+
+@pytest.mark.parametrize(
+    "invalid_arg",
+    [
+        "not a date range",
+        123,
+        45.6,
+        {"season": "2023/2024"},
+        None,
+    ],
+)
+def test_add_dates_invalid_type_error(invalid_arg: object) -> None:
+    """Test TypeError is raised when passing invalid types."""
+    model = VaxfluxModel(curve=LogisticCurve())
+
+    with pytest.raises(
+        TypeError,
+        match=r"Arguments must be DateRange objects or sequences of DateRange objects",
+    ):
+        model.add_dates(invalid_arg)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "invalid_item",
+    ["not a date range", 123, {"key": "value"}],
+    ids=["string", "int", "dict"],
+)
+def test_add_dates_sequence_with_invalid_items(invalid_item: object) -> None:
+    """Test TypeError is raised when a sequence contains non-DateRange items."""
+    model = VaxfluxModel(curve=LogisticCurve())
+    dr = DateRange(
+        season="2023/2024",
+        start_date=date(2023, 12, 1),
+        end_date=date(2023, 12, 7),
+        report_date=date(2023, 12, 8),
+    )
+
+    with pytest.raises(
+        TypeError,
+        match=r"All items in a sequence must be DateRange objects",
+    ):
+        model.add_dates([dr, invalid_item])  # type: ignore[list-item]
+
+
+def test_add_dates_exact_duplicate_in_single_call() -> None:
+    """Test ValueError is raised when duplicate date ranges are in a single call."""
+    model = VaxfluxModel(curve=LogisticCurve())
+    dr = DateRange(
+        season="2023/2024",
+        start_date=date(2023, 12, 1),
+        end_date=date(2023, 12, 7),
+        report_date=date(2023, 12, 8),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"Duplicate date range found:",
+    ):
+        model.add_dates(dr, dr)
+
+
+def test_add_dates_exact_duplicate_across_calls() -> None:
+    """Test ValueError is raised when adding an exact duplicate date range."""
+    model = VaxfluxModel(curve=LogisticCurve())
+    dr = DateRange(
+        season="2023/2024",
+        start_date=date(2023, 12, 1),
+        end_date=date(2023, 12, 7),
+        report_date=date(2023, 12, 8),
+    )
+
+    model.add_dates(dr)
+
+    with pytest.raises(
+        ValueError,
+        match=r"Date range already exists:",
+    ):
+        model.add_dates(dr)
+
+
+@pytest.mark.parametrize(
+    ("setup_dates", "test_dates_factory", "match_pattern"),
+    [
+        # Partial overlap in single call
+        (
+            None,
+            lambda: (
+                DateRange(
+                    season="2023/2024",
+                    start_date=date(2023, 12, 1),
+                    end_date=date(2023, 12, 7),
+                    report_date=date(2023, 12, 8),
+                ),
+                DateRange(
+                    season="2023/2024",
+                    start_date=date(2023, 12, 5),
+                    end_date=date(2023, 12, 12),
+                    report_date=date(2023, 12, 13),
+                ),
+            ),
+            r"Overlapping date ranges found: '2023/2024' \(2023-12-01 to 2023-12-07\) "
+            r"and '2023/2024' \(2023-12-05 to 2023-12-12\)\.",
+        ),
+        # One date range completely contains another
+        (
+            None,
+            lambda: (
+                DateRange(
+                    season="2023/2024",
+                    start_date=date(2023, 12, 1),
+                    end_date=date(2023, 12, 31),
+                    report_date=date(2024, 1, 1),
+                ),
+                DateRange(
+                    season="2023/2024",
+                    start_date=date(2023, 12, 10),
+                    end_date=date(2023, 12, 15),
+                    report_date=date(2023, 12, 16),
+                ),
+            ),
+            r"Overlapping date ranges found:",
+        ),
+        # Same dates, different report date
+        (
+            None,
+            lambda: (
+                DateRange(
+                    season="2023/2024",
+                    start_date=date(2023, 12, 1),
+                    end_date=date(2023, 12, 7),
+                    report_date=date(2023, 12, 8),
+                ),
+                DateRange(
+                    season="2023/2024",
+                    start_date=date(2023, 12, 1),
+                    end_date=date(2023, 12, 7),
+                    report_date=date(2023, 12, 9),
+                ),
+            ),
+            r"Overlapping date ranges found:",
+        ),
+        # Single day overlap
+        (
+            None,
+            lambda: (
+                DateRange(
+                    season="2023/2024",
+                    start_date=date(2023, 12, 1),
+                    end_date=date(2023, 12, 7),
+                    report_date=date(2023, 12, 8),
+                ),
+                DateRange(
+                    season="2023/2024",
+                    start_date=date(2023, 12, 7),
+                    end_date=date(2023, 12, 14),
+                    report_date=date(2023, 12, 15),
+                ),
+            ),
+            r"Overlapping date ranges found:",
+        ),
+        # Different seasons overlapping
+        (
+            None,
+            lambda: (
+                DateRange(
+                    season="2023/2024",
+                    start_date=date(2024, 1, 1),
+                    end_date=date(2024, 1, 7),
+                    report_date=date(2024, 1, 8),
+                ),
+                DateRange(
+                    season="2024/2025",
+                    start_date=date(2024, 1, 5),
+                    end_date=date(2024, 1, 12),
+                    report_date=date(2024, 1, 13),
+                ),
+            ),
+            r"Overlapping date ranges found:",
+        ),
+        # Overlap with existing date range (across calls)
+        (
+            [
+                DateRange(
+                    season="2023/2024",
+                    start_date=date(2023, 12, 1),
+                    end_date=date(2023, 12, 7),
+                    report_date=date(2023, 12, 8),
+                )
+            ],
+            lambda: (
+                DateRange(
+                    season="2023/2024",
+                    start_date=date(2023, 12, 5),
+                    end_date=date(2023, 12, 12),
+                    report_date=date(2023, 12, 13),
+                ),
+            ),
+            r"Overlapping date ranges found: existing '2023/2024'",
+        ),
+    ],
+    ids=[
+        "partial_overlap_single_call",
+        "complete_containment",
+        "same_dates_different_report",
+        "single_day_overlap",
+        "different_seasons_overlapping",
+        "overlap_with_existing",
+    ],
+)
+def test_add_dates_overlapping_errors(
+    setup_dates: list[DateRange] | None,
+    test_dates_factory: object,
+    match_pattern: str,
+) -> None:
+    """Test ValueError is raised for various overlapping date range scenarios."""
+    model = VaxfluxModel(curve=LogisticCurve())
+
+    # Add setup dates if provided (for testing across calls)
+    if setup_dates:
+        model.add_dates(*setup_dates)
+
+    # Generate test dates and expect overlap error
+    test_dates = test_dates_factory()  # type: ignore[operator]
+
+    with pytest.raises(ValueError, match=match_pattern):
+        model.add_dates(*test_dates)

--- a/tests/vaxflux_model_class/test_add_seasons.py
+++ b/tests/vaxflux_model_class/test_add_seasons.py
@@ -9,152 +9,171 @@ from vaxflux._vaxflux_model import VaxfluxModel
 from vaxflux.dates import SeasonRange
 
 
-def test_add_seasons_single_season() -> None:
-    """Test adding a single season."""
+@pytest.mark.parametrize(
+    ("args_factory", "expected_count"),
+    [
+        # Single season
+        (
+            lambda: (
+                SeasonRange(
+                    season="2023/2024",
+                    start_date=date(2023, 12, 1),
+                    end_date=date(2024, 3, 31),
+                ),
+            ),
+            1,
+        ),
+        # Multiple seasons as args
+        (
+            lambda: (
+                SeasonRange(
+                    season="2023/2024",
+                    start_date=date(2023, 12, 1),
+                    end_date=date(2024, 3, 31),
+                ),
+                SeasonRange(
+                    season="2024/2025",
+                    start_date=date(2024, 12, 1),
+                    end_date=date(2025, 3, 31),
+                ),
+                SeasonRange(
+                    season="2025/2026",
+                    start_date=date(2025, 12, 1),
+                    end_date=date(2026, 3, 31),
+                ),
+            ),
+            3,
+        ),
+        # List of seasons
+        (
+            lambda: (
+                [
+                    SeasonRange(
+                        season="2023/2024",
+                        start_date=date(2023, 12, 1),
+                        end_date=date(2024, 3, 31),
+                    ),
+                    SeasonRange(
+                        season="2024/2025",
+                        start_date=date(2024, 12, 1),
+                        end_date=date(2025, 3, 31),
+                    ),
+                ],
+            ),
+            2,
+        ),
+        # Tuple of seasons
+        (
+            lambda: (
+                (
+                    SeasonRange(
+                        season="2023/2024",
+                        start_date=date(2023, 12, 1),
+                        end_date=date(2024, 3, 31),
+                    ),
+                    SeasonRange(
+                        season="2024/2025",
+                        start_date=date(2024, 12, 1),
+                        end_date=date(2025, 3, 31),
+                    ),
+                ),
+            ),
+            2,
+        ),
+        # Mixed args and sequences
+        (
+            lambda: (
+                SeasonRange(
+                    season="2023/2024",
+                    start_date=date(2023, 12, 1),
+                    end_date=date(2024, 3, 31),
+                ),
+                [
+                    SeasonRange(
+                        season="2024/2025",
+                        start_date=date(2024, 12, 1),
+                        end_date=date(2025, 3, 31),
+                    ),
+                    SeasonRange(
+                        season="2025/2026",
+                        start_date=date(2025, 12, 1),
+                        end_date=date(2026, 3, 31),
+                    ),
+                ],
+                SeasonRange(
+                    season="2026/2027",
+                    start_date=date(2026, 12, 1),
+                    end_date=date(2027, 3, 31),
+                ),
+            ),
+            4,
+        ),
+        # Empty call
+        (lambda: (), 0),
+        # Empty list
+        (lambda: ([],), 0),
+        # Adjacent seasons (no overlap) - end date + 1 = next start date
+        (
+            lambda: (
+                SeasonRange(
+                    season="2023/2024",
+                    start_date=date(2023, 12, 1),
+                    end_date=date(2024, 3, 31),
+                ),
+                SeasonRange(
+                    season="2024/2025",
+                    start_date=date(2024, 4, 1),
+                    end_date=date(2024, 7, 31),
+                ),
+            ),
+            2,
+        ),
+        # Non-sequential but non-overlapping seasons - gap between seasons
+        (
+            lambda: (
+                SeasonRange(
+                    season="2023/2024",
+                    start_date=date(2023, 12, 1),
+                    end_date=date(2024, 3, 31),
+                ),
+                SeasonRange(
+                    season="2025/2026",
+                    start_date=date(2025, 12, 1),
+                    end_date=date(2026, 3, 31),
+                ),
+                SeasonRange(
+                    season="2024/2025",
+                    start_date=date(2024, 12, 1),
+                    end_date=date(2025, 3, 31),
+                ),
+            ),
+            3,
+        ),
+    ],
+    ids=[
+        "single_season",
+        "multiple_seasons_as_args",
+        "list_of_seasons",
+        "tuple_of_seasons",
+        "mixed_args_and_sequences",
+        "empty_call",
+        "empty_list",
+        "adjacent_seasons_no_overlap",
+        "non_sequential_non_overlapping",
+    ],
+)
+def test_add_seasons_input_variations(
+    args_factory: object, expected_count: int
+) -> None:
+    """Test adding seasons with various input patterns."""
     model = VaxfluxModel(curve=LogisticCurve())
-    season = SeasonRange(
-        season="2023/2024",
-        start_date=date(2023, 12, 1),
-        end_date=date(2024, 3, 31),
-    )
-    result = model.add_seasons(season)
+    args = args_factory()  # type: ignore[operator]
+    result = model.add_seasons(*args)
 
     # Check method chaining works
     assert result is model
-    # Check season was added
-    assert len(model._seasons) == 1
-    assert model._seasons[0] == season
-
-
-def test_add_seasons_multiple_seasons_as_args() -> None:
-    """Test adding multiple seasons as individual arguments."""
-    model = VaxfluxModel(curve=LogisticCurve())
-    season1 = SeasonRange(
-        season="2023/2024",
-        start_date=date(2023, 12, 1),
-        end_date=date(2024, 3, 31),
-    )
-    season2 = SeasonRange(
-        season="2024/2025",
-        start_date=date(2024, 12, 1),
-        end_date=date(2025, 3, 31),
-    )
-    season3 = SeasonRange(
-        season="2025/2026",
-        start_date=date(2025, 12, 1),
-        end_date=date(2026, 3, 31),
-    )
-
-    result = model.add_seasons(season1, season2, season3)
-
-    # Check method chaining works
-    assert result is model
-    # Check all seasons were added
-    assert len(model._seasons) == 3
-    assert model._seasons[0] == season1
-    assert model._seasons[1] == season2
-    assert model._seasons[2] == season3
-
-
-def test_add_seasons_list() -> None:
-    """Test adding seasons as a list."""
-    model = VaxfluxModel(curve=LogisticCurve())
-    seasons = [
-        SeasonRange(
-            season="2023/2024",
-            start_date=date(2023, 12, 1),
-            end_date=date(2024, 3, 31),
-        ),
-        SeasonRange(
-            season="2024/2025",
-            start_date=date(2024, 12, 1),
-            end_date=date(2025, 3, 31),
-        ),
-    ]
-
-    result = model.add_seasons(seasons)
-
-    # Check method chaining works
-    assert result is model
-    # Check all seasons were added
-    assert len(model._seasons) == 2
-    assert model._seasons[0] == seasons[0]
-    assert model._seasons[1] == seasons[1]
-
-
-def test_add_seasons_tuple() -> None:
-    """Test adding seasons as a tuple."""
-    model = VaxfluxModel(curve=LogisticCurve())
-    seasons = (
-        SeasonRange(
-            season="2023/2024",
-            start_date=date(2023, 12, 1),
-            end_date=date(2024, 3, 31),
-        ),
-        SeasonRange(
-            season="2024/2025",
-            start_date=date(2024, 12, 1),
-            end_date=date(2025, 3, 31),
-        ),
-    )
-
-    result = model.add_seasons(seasons)
-
-    # Check method chaining works
-    assert result is model
-    # Check all seasons were added
-    assert len(model._seasons) == 2
-    assert model._seasons[0] == seasons[0]
-    assert model._seasons[1] == seasons[1]
-
-
-def test_add_seasons_mixed_args_and_sequences() -> None:
-    """Test adding seasons with mixed individual and sequence arguments."""
-    model = VaxfluxModel(curve=LogisticCurve())
-    season1 = SeasonRange(
-        season="2023/2024",
-        start_date=date(2023, 12, 1),
-        end_date=date(2024, 3, 31),
-    )
-    seasons_list = [
-        SeasonRange(
-            season="2024/2025",
-            start_date=date(2024, 12, 1),
-            end_date=date(2025, 3, 31),
-        ),
-        SeasonRange(
-            season="2025/2026",
-            start_date=date(2025, 12, 1),
-            end_date=date(2026, 3, 31),
-        ),
-    ]
-    season4 = SeasonRange(
-        season="2026/2027",
-        start_date=date(2026, 12, 1),
-        end_date=date(2027, 3, 31),
-    )
-
-    result = model.add_seasons(season1, seasons_list, season4)
-
-    # Check method chaining works
-    assert result is model
-    # Check all seasons were added
-    assert len(model._seasons) == 4
-    assert model._seasons[0] == season1
-    assert model._seasons[1] == seasons_list[0]
-    assert model._seasons[2] == seasons_list[1]
-    assert model._seasons[3] == season4
-
-
-def test_add_seasons_empty_call() -> None:
-    """Test calling add_seasons with no arguments."""
-    model = VaxfluxModel(curve=LogisticCurve())
-    result = model.add_seasons()
-
-    # Check method chaining works
-    assert result is model
-    # Check no seasons were added
-    assert len(model._seasons) == 0
+    # Check expected number of seasons were added
+    assert len(model._seasons) == expected_count
 
 
 def test_add_seasons_multiple_calls() -> None:
@@ -225,24 +244,13 @@ def test_add_seasons_invalid_type_error(invalid_arg: object) -> None:
         model.add_seasons(invalid_arg)  # type: ignore[arg-type]
 
 
-def test_add_seasons_sequence_with_invalid_items() -> None:
+@pytest.mark.parametrize(
+    "invalid_item",
+    ["not a season", 123, {"key": "value"}],
+    ids=["string", "int", "dict"],
+)
+def test_add_seasons_sequence_with_invalid_items(invalid_item: object) -> None:
     """Test TypeError is raised when a sequence contains non-SeasonRange items."""
-    model = VaxfluxModel(curve=LogisticCurve())
-    season = SeasonRange(
-        season="2023/2024",
-        start_date=date(2023, 12, 1),
-        end_date=date(2024, 3, 31),
-    )
-
-    with pytest.raises(
-        TypeError,
-        match=r"All items in a sequence must be SeasonRange objects, got str\.",
-    ):
-        model.add_seasons([season, "not a season"])  # type: ignore[list-item]
-
-
-def test_add_seasons_sequence_with_mixed_invalid_items() -> None:
-    """Test TypeError is raised with various invalid items in a sequence."""
     model = VaxfluxModel(curve=LogisticCurve())
     season = SeasonRange(
         season="2023/2024",
@@ -254,18 +262,7 @@ def test_add_seasons_sequence_with_mixed_invalid_items() -> None:
         TypeError,
         match=r"All items in a sequence must be SeasonRange objects",
     ):
-        model.add_seasons([season, 123])  # type: ignore[list-item]
-
-
-def test_add_seasons_empty_list() -> None:
-    """Test adding an empty list."""
-    model = VaxfluxModel(curve=LogisticCurve())
-    result = model.add_seasons([])
-
-    # Check method chaining works
-    assert result is model
-    # Check no seasons were added
-    assert len(model._seasons) == 0
+        model.add_seasons([season, invalid_item])  # type: ignore[list-item]
 
 
 def test_add_seasons_preserves_existing_seasons() -> None:
@@ -300,244 +297,214 @@ def test_add_seasons_preserves_existing_seasons() -> None:
     assert model._seasons[2] == season3
 
 
-# Validation tests
-
-
-def test_add_seasons_duplicate_names_in_single_call() -> None:
-    """Test ValueError is raised when duplicate season names are in a single call."""
-    model = VaxfluxModel(curve=LogisticCurve())
-    season1 = SeasonRange(
-        season="2023/2024",
-        start_date=date(2023, 12, 1),
-        end_date=date(2024, 3, 31),
-    )
-    season2_duplicate = SeasonRange(
-        season="2023/2024",  # Same name as season1
-        start_date=date(2024, 12, 1),
-        end_date=date(2025, 3, 31),
-    )
-
-    with pytest.raises(
-        ValueError,
-        match=r"Duplicate season names found in new seasons: \['2023/2024'\]\.",
-    ):
-        model.add_seasons(season1, season2_duplicate)
-
-
-def test_add_seasons_duplicate_names_across_calls() -> None:
-    """Test ValueError is raised when adding a season with an existing name."""
-    model = VaxfluxModel(curve=LogisticCurve())
-    season1 = SeasonRange(
-        season="2023/2024",
-        start_date=date(2023, 12, 1),
-        end_date=date(2024, 3, 31),
-    )
-    season2_duplicate = SeasonRange(
-        season="2023/2024",  # Same name as season1
-        start_date=date(2024, 12, 1),
-        end_date=date(2025, 3, 31),
-    )
-
-    model.add_seasons(season1)
-
-    with pytest.raises(
-        ValueError,
-        match=r"Season names already exist in the model: \['2023/2024'\]\.",
-    ):
-        model.add_seasons(season2_duplicate)
-
-
-def test_add_seasons_multiple_duplicate_names() -> None:
-    """Test ValueError lists all duplicate season names."""
-    model = VaxfluxModel(curve=LogisticCurve())
-    season1 = SeasonRange(
-        season="2023/2024",
-        start_date=date(2023, 12, 1),
-        end_date=date(2024, 3, 31),
-    )
-    season2 = SeasonRange(
-        season="2024/2025",
-        start_date=date(2024, 12, 1),
-        end_date=date(2025, 3, 31),
-    )
-    season1_dup = SeasonRange(
-        season="2023/2024",
-        start_date=date(2025, 12, 1),
-        end_date=date(2026, 3, 31),
-    )
-    season2_dup = SeasonRange(
-        season="2024/2025",
-        start_date=date(2026, 12, 1),
-        end_date=date(2027, 3, 31),
-    )
-
-    with pytest.raises(
-        ValueError,
-        match=(
-            r"Duplicate season names found in new "
-            r"seasons: \['2023/2024', '2024/2025'\]\."
+@pytest.mark.parametrize(
+    ("setup_seasons", "test_seasons_factory", "match_pattern"),
+    [
+        # Single duplicate season name in one call
+        (
+            None,
+            lambda: (
+                SeasonRange(
+                    season="2023/2024",
+                    start_date=date(2023, 12, 1),
+                    end_date=date(2024, 3, 31),
+                ),
+                SeasonRange(
+                    season="2023/2024",
+                    start_date=date(2024, 12, 1),
+                    end_date=date(2025, 3, 31),
+                ),
+            ),
+            r"Duplicate season names found in new seasons: \['2023/2024'\]\.",
         ),
-    ):
-        model.add_seasons(season1, season2, season1_dup, season2_dup)
-
-
-def test_add_seasons_overlapping_dates_in_single_call() -> None:
-    """Test ValueError is raised when seasons have overlapping dates."""
+        # Multiple duplicate season names in one call
+        (
+            None,
+            lambda: (
+                SeasonRange(
+                    season="2023/2024",
+                    start_date=date(2023, 12, 1),
+                    end_date=date(2024, 3, 31),
+                ),
+                SeasonRange(
+                    season="2024/2025",
+                    start_date=date(2024, 12, 1),
+                    end_date=date(2025, 3, 31),
+                ),
+                SeasonRange(
+                    season="2023/2024",
+                    start_date=date(2025, 12, 1),
+                    end_date=date(2026, 3, 31),
+                ),
+                SeasonRange(
+                    season="2024/2025",
+                    start_date=date(2026, 12, 1),
+                    end_date=date(2027, 3, 31),
+                ),
+            ),
+            (
+                r"Duplicate season names found in new "
+                r"seasons: \['2023/2024', '2024/2025'\]\."
+            ),
+        ),
+        # Duplicate season name across calls
+        (
+            [
+                SeasonRange(
+                    season="2023/2024",
+                    start_date=date(2023, 12, 1),
+                    end_date=date(2024, 3, 31),
+                )
+            ],
+            lambda: (
+                SeasonRange(
+                    season="2023/2024",
+                    start_date=date(2024, 12, 1),
+                    end_date=date(2025, 3, 31),
+                ),
+            ),
+            r"Season names already exist in the model: \['2023/2024'\]\.",
+        ),
+    ],
+    ids=[
+        "single_duplicate_name",
+        "multiple_duplicate_names",
+        "duplicate_with_existing",
+    ],
+)
+def test_add_seasons_duplicate_name_errors(
+    setup_seasons: list[SeasonRange] | None,
+    test_seasons_factory: object,
+    match_pattern: str,
+) -> None:
+    """Test ValueError is raised for various duplicate season name scenarios."""
     model = VaxfluxModel(curve=LogisticCurve())
-    season1 = SeasonRange(
-        season="2023/2024",
-        start_date=date(2023, 12, 1),
-        end_date=date(2024, 3, 31),
-    )
-    season2_overlapping = SeasonRange(
-        season="2024 Winter",
-        start_date=date(2024, 3, 1),  # Overlaps with season1
-        end_date=date(2024, 5, 31),
-    )
 
-    with pytest.raises(
-        ValueError,
-        match=(
+    # Add setup seasons if provided (for testing across calls)
+    if setup_seasons:
+        model.add_seasons(*setup_seasons)
+
+    # Generate test seasons and expect duplicate name error
+    test_seasons = test_seasons_factory()  # type: ignore[operator]
+
+    with pytest.raises(ValueError, match=match_pattern):
+        model.add_seasons(*test_seasons)
+
+
+@pytest.mark.parametrize(
+    ("setup_seasons", "test_seasons_factory", "match_pattern"),
+    [
+        # Partial overlap in single call
+        (
+            None,
+            lambda: (
+                SeasonRange(
+                    season="2023/2024",
+                    start_date=date(2023, 12, 1),
+                    end_date=date(2024, 3, 31),
+                ),
+                SeasonRange(
+                    season="2024 Winter",
+                    start_date=date(2024, 3, 1),
+                    end_date=date(2024, 5, 31),
+                ),
+            ),
             r"Overlapping date ranges found: '2023/2024' \(2023-12-01 to 2024-03-31\) "
-            r"and '2024 Winter' \(2024-03-01 to 2024-05-31\)\."
+            r"and '2024 Winter' \(2024-03-01 to 2024-05-31\)\.",
         ),
-    ):
-        model.add_seasons(season1, season2_overlapping)
-
-
-def test_add_seasons_overlapping_dates_across_calls() -> None:
-    """Test ValueError is raised when new season overlaps with existing season."""
-    model = VaxfluxModel(curve=LogisticCurve())
-    season1 = SeasonRange(
-        season="2023/2024",
-        start_date=date(2023, 12, 1),
-        end_date=date(2024, 3, 31),
-    )
-    season2_overlapping = SeasonRange(
-        season="2024 Winter",
-        start_date=date(2024, 3, 1),  # Overlaps with season1
-        end_date=date(2024, 5, 31),
-    )
-
-    model.add_seasons(season1)
-
-    with pytest.raises(
-        ValueError,
-        match=(
+        # One season completely contains another
+        (
+            None,
+            lambda: (
+                SeasonRange(
+                    season="2023/2024",
+                    start_date=date(2023, 12, 1),
+                    end_date=date(2024, 3, 31),
+                ),
+                SeasonRange(
+                    season="2024 January",
+                    start_date=date(2024, 1, 1),
+                    end_date=date(2024, 1, 31),
+                ),
+            ),
+            r"Overlapping date ranges found:",
+        ),
+        # Identical date ranges (different season names)
+        (
+            None,
+            lambda: (
+                SeasonRange(
+                    season="2023/2024 A",
+                    start_date=date(2023, 12, 1),
+                    end_date=date(2024, 3, 31),
+                ),
+                SeasonRange(
+                    season="2023/2024 B",
+                    start_date=date(2023, 12, 1),
+                    end_date=date(2024, 3, 31),
+                ),
+            ),
+            r"Overlapping date ranges found:",
+        ),
+        # Single day overlap
+        (
+            None,
+            lambda: (
+                SeasonRange(
+                    season="2023/2024",
+                    start_date=date(2023, 12, 1),
+                    end_date=date(2024, 3, 31),
+                ),
+                SeasonRange(
+                    season="2024/2025",
+                    start_date=date(2024, 3, 31),
+                    end_date=date(2024, 7, 31),
+                ),
+            ),
+            r"Overlapping date ranges found:",
+        ),
+        # Overlap with existing season (across calls)
+        (
+            [
+                SeasonRange(
+                    season="2023/2024",
+                    start_date=date(2023, 12, 1),
+                    end_date=date(2024, 3, 31),
+                )
+            ],
+            lambda: (
+                SeasonRange(
+                    season="2024 Winter",
+                    start_date=date(2024, 3, 1),
+                    end_date=date(2024, 5, 31),
+                ),
+            ),
             r"Overlapping date ranges found: '2023/2024' \(2023-12-01 to 2024-03-31\) "
-            r"and '2024 Winter' \(2024-03-01 to 2024-05-31\)\."
+            r"and '2024 Winter' \(2024-03-01 to 2024-05-31\)\.",
         ),
-    ):
-        model.add_seasons(season2_overlapping)
-
-
-def test_add_seasons_completely_overlapping_dates() -> None:
-    """Test ValueError when one season completely contains another."""
+    ],
+    ids=[
+        "partial_overlap_single_call",
+        "complete_containment",
+        "identical_date_ranges",
+        "single_day_overlap",
+        "overlap_with_existing",
+    ],
+)
+def test_add_seasons_overlapping_errors(
+    setup_seasons: list[SeasonRange] | None,
+    test_seasons_factory: object,
+    match_pattern: str,
+) -> None:
+    """Test ValueError is raised for various overlapping season scenarios."""
     model = VaxfluxModel(curve=LogisticCurve())
-    season1 = SeasonRange(
-        season="2023/2024",
-        start_date=date(2023, 12, 1),
-        end_date=date(2024, 3, 31),
-    )
-    season2_contained = SeasonRange(
-        season="2024 January",
-        start_date=date(2024, 1, 1),  # Inside season1
-        end_date=date(2024, 1, 31),
-    )
 
-    with pytest.raises(
-        ValueError,
-        match=r"Overlapping date ranges found:",
-    ):
-        model.add_seasons(season1, season2_contained)
+    # Add setup seasons if provided (for testing across calls)
+    if setup_seasons:
+        model.add_seasons(*setup_seasons)
 
+    # Generate test seasons and expect overlap error
+    test_seasons = test_seasons_factory()  # type: ignore[operator]
 
-def test_add_seasons_same_dates() -> None:
-    """Test ValueError when seasons have identical date ranges."""
-    model = VaxfluxModel(curve=LogisticCurve())
-    season1 = SeasonRange(
-        season="2023/2024 A",
-        start_date=date(2023, 12, 1),
-        end_date=date(2024, 3, 31),
-    )
-    season2_same_dates = SeasonRange(
-        season="2023/2024 B",
-        start_date=date(2023, 12, 1),  # Same dates
-        end_date=date(2024, 3, 31),
-    )
-
-    with pytest.raises(
-        ValueError,
-        match=r"Overlapping date ranges found:",
-    ):
-        model.add_seasons(season1, season2_same_dates)
-
-
-def test_add_seasons_adjacent_dates_no_overlap() -> None:
-    """Test that adjacent seasons (no overlap) are allowed."""
-    model = VaxfluxModel(curve=LogisticCurve())
-    season1 = SeasonRange(
-        season="2023/2024",
-        start_date=date(2023, 12, 1),
-        end_date=date(2024, 3, 31),
-    )
-    season2_adjacent = SeasonRange(
-        season="2024/2025",
-        start_date=date(2024, 4, 1),  # Day after season1 ends
-        end_date=date(2024, 7, 31),
-    )
-
-    # Should not raise an error
-    result = model.add_seasons(season1, season2_adjacent)
-
-    assert result is model
-    assert len(model._seasons) == 2
-    assert model._seasons[0] == season1
-    assert model._seasons[1] == season2_adjacent
-
-
-def test_add_seasons_single_day_overlap() -> None:
-    """Test ValueError when seasons overlap by a single day."""
-    model = VaxfluxModel(curve=LogisticCurve())
-    season1 = SeasonRange(
-        season="2023/2024",
-        start_date=date(2023, 12, 1),
-        end_date=date(2024, 3, 31),
-    )
-    season2_one_day_overlap = SeasonRange(
-        season="2024/2025",
-        start_date=date(2024, 3, 31),  # Same as season1 end date
-        end_date=date(2024, 7, 31),
-    )
-
-    with pytest.raises(
-        ValueError,
-        match=r"Overlapping date ranges found:",
-    ):
-        model.add_seasons(season1, season2_one_day_overlap)
-
-
-def test_add_seasons_non_sequential_but_non_overlapping() -> None:
-    """Test that non-sequential but non-overlapping seasons are allowed."""
-    model = VaxfluxModel(curve=LogisticCurve())
-    season1 = SeasonRange(
-        season="2023/2024",
-        start_date=date(2023, 12, 1),
-        end_date=date(2024, 3, 31),
-    )
-    season2 = SeasonRange(
-        season="2025/2026",
-        start_date=date(2025, 12, 1),  # Gap between seasons
-        end_date=date(2026, 3, 31),
-    )
-    season3 = SeasonRange(
-        season="2024/2025",
-        start_date=date(2024, 12, 1),  # Fills the gap
-        end_date=date(2025, 3, 31),
-    )
-
-    # Should not raise an error
-    result = model.add_seasons(season1, season2, season3)
-
-    assert result is model
-    assert len(model._seasons) == 3
+    with pytest.raises(ValueError, match=match_pattern):
+        model.add_seasons(*test_seasons)


### PR DESCRIPTION
Added `add_dates` method for specifying date ranges to a `VaxfluxModel`. Attempted to use the same underlying infrastructure that `add_seasons` uses, so work consolidating to private helpers in `vaxflux.dates` is included. Also added unit tests that are consolidated and performed the same consolidation for the `add_seasons` unit tests.

Closes #105.