### PR TITLE
Add `add_covariates/add_covariate_categories`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ Added:
   [accidda.github.io/vaxflux/](https://accidda.github.io/vaxflux/), see
   [#62](https://github.com/ACCIDDA/vaxflux/issues/62).
 - Added `VaxfluxModel` and new `Curve` classes that are based on
-  `jax`/`numpyro`. See [#105](https://github.com/ACCIDDA/vaxflux/issues/105).
+  `jax`/`numpyro`. See [#105](https://github.com/ACCIDDA/vaxflux/issues/105),
+  [#106](https://github.com/ACCIDDA/vaxflux/issues/106).
 
 Changed:
 

--- a/cspell.json
+++ b/cspell.json
@@ -68,6 +68,7 @@
     "numpyro",
     "operatorname",
     "pprint",
+    "presample",
     "priord",
     "prng",
     "pygments",

--- a/src/vaxflux/__init__.py
+++ b/src/vaxflux/__init__.py
@@ -1,8 +1,10 @@
 """Model seasonal vaccination uptake curves."""
 
 __all__ = (
+    "Covariate",
     "Curve",
     "LogisticCurve",
+    "PartiallyPooledGaussianCovariate",
     "VaxfluxModel",
     "covariates",
     "curves",
@@ -22,5 +24,6 @@ from vaxflux import (
     interventions,
     uptake,
 )
+from vaxflux._covariates import Covariate, PartiallyPooledGaussianCovariate
 from vaxflux._curves import Curve, LogisticCurve
 from vaxflux._vaxflux_model import VaxfluxModel

--- a/src/vaxflux/_covariates.py
+++ b/src/vaxflux/_covariates.py
@@ -1,0 +1,94 @@
+from abc import ABC, abstractmethod
+from typing import cast
+
+import numpyro
+import numpyro.distributions as dist
+from pydantic import BaseModel, Field
+
+from vaxflux._types import NumericalArrayLike
+
+
+class Covariate(ABC, BaseModel):
+    """
+    Abstract base class for covariates in vaxflux.
+
+    Attributes:
+        parameter: The name of the model parameter this covariate affects.
+        covariate: The name of the covariate variable.
+    """
+
+    parameter: str
+    covariate: str | None = None
+
+    @property
+    def prefix(self) -> str:
+        """
+        Get the prefix for the covariate based on the parameter name.
+
+        Returns:
+            The prefix string derived from the parameter name.
+        """
+        return self.parameter + (f"_{self.covariate}" if self.covariate else "")
+
+    def presample(self) -> None:
+        """
+        Hook method for any pre-sampling steps required before sampling.
+
+        This method can be overridden by subclasses if needed.
+        """
+
+    @abstractmethod
+    def sample(self) -> NumericalArrayLike:
+        """
+        Abstract method to sample the covariate values.
+
+        Returns:
+            A numerical array-like structure containing the sampled covariate values.
+        """
+        raise NotImplementedError
+
+
+class PartiallyPooledGaussianCovariate(Covariate):
+    r"""
+    Covariate model using a pooled Gaussian approach.
+
+    $$ \\mu_i \\sim \\mathrm{Normal}(\\mu_0, \\mu_1) $$
+
+    $$ \\sigma_i \\sim \\mathrm{Half}\\text{-}\\mathrm{Normal}(\\sigma) $$
+
+    $$ x_i \\sim \\mathrm{Normal}(\\mu_i, \\sigma_i) $$
+
+    Attributes:
+        mu: A tuple representing the location and scale of the partially pooled mean.
+        sigma: The scale of the half-normal distribution for the standard deviation.
+    """
+
+    mu: tuple[float, float]
+    sigma: float = Field(gt=0.0)
+
+    def presample(self) -> None:
+        """
+        Hook method for any pre-sampling steps required before sampling.
+
+        This method can be overridden by subclasses if needed.
+        """
+        self._mu_sample = numpyro.sample(
+            f"{self.prefix}_mu", dist.Normal(self.mu[0], self.mu[1])
+        )
+        self._sigma_sample = numpyro.sample(
+            f"{self.prefix}_sigma", dist.HalfNormal(self.sigma)
+        )
+
+    def sample(self) -> NumericalArrayLike:
+        """
+        Sample values from a Gaussian distribution defined by the mean and stddev.
+
+        Returns:
+            A numerical array-like structure containing the sampled covariate values.
+        """
+        return cast(
+            "NumericalArrayLike",
+            numpyro.sample(
+                self.prefix, dist.Normal(self._mu_sample, self._sigma_sample)
+            ),
+        )

--- a/src/vaxflux/_util.py
+++ b/src/vaxflux/_util.py
@@ -2,8 +2,8 @@ __all__: tuple[str, ...] = ()
 
 
 import re
-from collections.abc import Callable
-from typing import Annotated, Any, Final, overload
+from collections.abc import Callable, Sequence
+from typing import Annotated, Any, Final, TypeVar, overload
 
 import pandas as pd
 from pandas.api.types import is_datetime64_any_dtype
@@ -18,6 +18,63 @@ _REQUIRED_OBSERVATION_COLUMNS: Final = {
     "type",
     "value",
 }
+
+T = TypeVar("T")
+
+
+def _collect_args(
+    args: tuple[T | Sequence[T], ...],
+    expected_type: type[T],
+    type_name: str,
+) -> list[T]:
+    """Collect and validate objects from arguments.
+
+    Args:
+        args: Variable arguments that can be objects or sequences of objects.
+        expected_type: The expected type of the objects.
+        type_name: Name of the type for error messages.
+
+    Returns:
+        List of validated objects.
+
+    Raises:
+        TypeError: If arguments are not of the expected type.
+
+    Examples:
+        >>> from vaxflux._util import _collect_args
+        >>> _collect_args((1, 2, 3), int, "int")
+        [1, 2, 3]
+        >>> _collect_args(([1, 2], 3), int, "int")
+        [1, 2, 3]
+        >>> _collect_args((1, [2, 3], 4), int, "int")
+        [1, 2, 3, 4]
+        >>> _collect_args(("not an int",), int, "int")
+        Traceback (most recent call last):
+            ...
+        TypeError: Arguments must be int objects or sequences of int objects, got str.
+
+    """
+    items: list[T] = []
+    for arg in args:
+        if isinstance(arg, expected_type):
+            items.append(arg)
+        elif isinstance(arg, Sequence) and not isinstance(arg, (str, bytes)):
+            # Validate that all items in the sequence are of expected type
+            for item in arg:
+                if not isinstance(item, expected_type):
+                    msg = (
+                        f"All items in a sequence must be {type_name} objects, "
+                        f"got {type(item).__name__}."
+                    )
+                    raise TypeError(msg)
+            items.extend(arg)
+        else:
+            msg = (
+                f"Arguments must be {type_name} objects or sequences of "
+                f"{type_name} objects, got {type(arg).__name__}."
+            )
+            raise TypeError(msg)
+    return items
 
 
 def _clean_name(

--- a/src/vaxflux/_vaxflux_model.py
+++ b/src/vaxflux/_vaxflux_model.py
@@ -6,7 +6,10 @@ import numpyro
 from jax.random import key
 from numpyro.infer import MCMC, NUTS
 
+from vaxflux._covariates import Covariate
 from vaxflux._curves import Curve
+from vaxflux._util import _collect_args
+from vaxflux.covariates import CovariateCategories
 from vaxflux.dates import (
     DateRange,
     SeasonRange,
@@ -27,6 +30,8 @@ class VaxfluxModel:
         self._curve = curve
         self._seasons: list[SeasonRange] = []
         self._dates: list[DateRange] = []
+        self._covariate_categories: list[CovariateCategories] = []
+        self._covariates: list[Covariate] = []
 
     def add_seasons(self, *args: SeasonRange | list[SeasonRange]) -> Self:
         """
@@ -128,6 +133,75 @@ class VaxfluxModel:
         dates = _collect_ranges(args, DateRange, "DateRange")
         _validate_ranges(dates, self._dates)
         self._dates.extend(dates)
+        return self
+
+    def add_covariate_categories(
+        self, *args: CovariateCategories | list[CovariateCategories]
+    ) -> Self:
+        """
+        Add one or more covariate categories to the model.
+
+        Args:
+            *args: One or more `CovariateCategories` objects or sequences of
+                `CovariateCategories` objects.
+
+        Returns:
+            The model instance for method chaining.
+
+        Raises:
+            TypeError: If any argument is not a `CovariateCategories` or a sequence of
+                `CovariateCategories` objects.
+
+        """
+        covariate_categories = _collect_args(
+            args, CovariateCategories, "CovariateCategories"
+        )
+        self._covariate_categories.extend(covariate_categories)
+        return self
+
+    def add_covariates(self, *args: Covariate | list[Covariate]) -> Self:
+        """
+        Add one or more covariates to the model.
+
+        Args:
+            *args: One or more `Covariate` objects or sequences of `Covariate` objects.
+
+        Returns:
+            The model instance for method chaining.
+
+        Raises:
+            TypeError: If any argument is not a `Covariate` or a sequence of
+                `Covariate` objects.
+
+        Examples:
+            >>> from vaxflux._covariates import PartiallyPooledGaussianCovariate
+            >>> from vaxflux._curves import LogisticCurve
+            >>> model = VaxfluxModel(curve=LogisticCurve())
+            >>> result = model.add_covariates(
+            ...     PartiallyPooledGaussianCovariate(
+            ...         parameter="m",
+            ...         covariate="age",
+            ...         mu=(0.5, 0.1),
+            ...         sigma=0.2,
+            ...     )
+            ... )
+            >>> result = model.add_covariates(
+            ...     [
+            ...         PartiallyPooledGaussianCovariate(
+            ...             parameter="sigma",
+            ...             mu=(0.2, 0.03),
+            ...             sigma=0.1,
+            ...         ),
+            ...     ]
+            ... )
+            >>> model.add_covariates("invalid_argument")
+            Traceback (most recent call last):
+                ...
+            TypeError: Arguments must be Covariate objects or sequences of Covariate objects, got str.
+
+        """  # noqa: E501
+        covariates = _collect_args(args, Covariate, "Covariate")  # type: ignore[type-abstract]
+        self._covariates.extend(covariates)
         return self
 
     def sample(

--- a/src/vaxflux/dates.py
+++ b/src/vaxflux/dates.py
@@ -10,6 +10,8 @@ from typing import Final, Literal, NamedTuple, TypeVar
 import pandas as pd
 from pydantic import BaseModel, ConfigDict, model_validator
 
+from vaxflux._util import _collect_args
+
 _INFER_RANGES_REQUIRED_COLUMNS: Final[dict[Literal["date", "season"], set[str]]] = {
     "date": {"season", "start_date", "end_date", "report_date"},
     "season": {"season", "start_date", "end_date"},
@@ -313,27 +315,7 @@ def _collect_ranges(
     Raises:
         TypeError: If arguments are not of the expected type.
     """
-    ranges: list[Range] = []
-    for arg in args:
-        if isinstance(arg, expected_type):
-            ranges.append(arg)
-        elif isinstance(arg, Sequence) and not isinstance(arg, (str, bytes)):
-            # Validate that all items in the sequence are of expected type
-            for item in arg:
-                if not isinstance(item, expected_type):
-                    msg = (
-                        f"All items in a sequence must be {type_name} objects, "
-                        f"got {type(item).__name__}."
-                    )
-                    raise TypeError(msg)
-            ranges.extend(arg)
-        else:
-            msg = (
-                f"Arguments must be {type_name} objects or sequences of "
-                f"{type_name} objects, got {type(arg).__name__}."
-            )
-            raise TypeError(msg)
-    return ranges
+    return _collect_args(args, expected_type, type_name)
 
 
 def _validate_ranges(

--- a/tests/_util/test__collect_args.py
+++ b/tests/_util/test__collect_args.py
@@ -1,0 +1,159 @@
+"""Unit tests for the `vaxflux._util._collect_args` function."""
+
+import pytest
+
+from vaxflux._util import _collect_args
+
+
+@pytest.mark.parametrize(
+    ("args_factory", "expected_count"),
+    [
+        # Single object
+        (lambda: (1,), 1),
+        # Multiple objects as args
+        (lambda: (1, 2, 3), 3),
+        # List of objects
+        (lambda: ([1, 2, 3],), 3),
+        # Tuple of objects
+        (lambda: ((1, 2, 3),), 3),
+        # Mixed args and sequences
+        (lambda: (1, [2, 3], 4), 4),
+        # Multiple sequences
+        (lambda: ([1, 2], [3, 4]), 4),
+        # Mixed single and multiple sequences
+        (lambda: (1, [2, 3], 4, [5, 6, 7]), 7),
+        # Empty call
+        (lambda: (), 0),
+        # Empty list
+        (lambda: ([],), 0),
+        # Empty tuple
+        (lambda: ((),), 0),
+        # Multiple empty sequences
+        (lambda: ([], (), []), 0),
+        # Mix of empty and non-empty sequences
+        (lambda: ([], 1, (), 2, []), 2),
+    ],
+)
+def test_input_variations(args_factory: object, expected_count: int) -> None:
+    """Test collecting objects with various input patterns."""
+    args = args_factory()  # type: ignore[operator]
+    result = _collect_args(args, int, "int")
+
+    # Check expected number of objects were collected
+    assert len(result) == expected_count
+    # Check all items are integers
+    assert all(isinstance(item, int) for item in result)
+    # Check result is a list
+    assert isinstance(result, list)
+
+
+def test_preserves_order() -> None:
+    """Test that _collect_args preserves the order of items."""
+    args = (3, [1, 2], 5, [4, 6], 7)
+    result = _collect_args(args, int, "int")
+
+    assert result == [3, 1, 2, 5, 4, 6, 7]
+
+
+def test_with_different_types() -> None:
+    """Test that _collect_args works with different object types."""
+
+    class TestClass:
+        def __init__(self, value: int) -> None:
+            self.value = value
+
+    obj1 = TestClass(1)
+    obj2 = TestClass(2)
+    obj3 = TestClass(3)
+
+    args = (obj1, [obj2, obj3])
+    result = _collect_args(args, TestClass, "TestClass")
+
+    assert len(result) == 3
+    assert all(isinstance(item, TestClass) for item in result)
+    assert result[0].value == 1
+    assert result[1].value == 2
+    assert result[2].value == 3
+
+
+@pytest.mark.parametrize(
+    "invalid_arg", ["not an int", 12.5, {"key": "value"}, None, object()]
+)
+def test_invalid_type_error(invalid_arg: object) -> None:
+    """Test TypeError is raised when passing invalid types."""
+    with pytest.raises(
+        TypeError,
+        match=r"Arguments must be int objects or sequences of int objects, got \w+\.",
+    ):
+        _collect_args((invalid_arg,), int, "int")
+
+
+@pytest.mark.parametrize("invalid_item", ["not an int", 12.5, {"key": "value"}])
+def test_sequence_with_invalid_items(invalid_item: object) -> None:
+    """Test TypeError is raised when a sequence contains invalid items."""
+    with pytest.raises(
+        TypeError,
+        match=r"All items in a sequence must be int objects, got \w+\.",
+    ):
+        _collect_args(([1, 2, invalid_item],), int, "int")  # type: ignore[list-item]
+
+
+@pytest.mark.parametrize("word", ["abc", b"abc"])
+def test_string_and_bytes_not_treated_as_sequence(word: str | bytes) -> None:
+    """Test that strings are not treated as sequences even though they're iterable."""
+    with pytest.raises(
+        TypeError,
+        match=r"Arguments must be int objects or sequences of int objects, got \w+\.",
+    ):
+        _collect_args((word,), int, "int")
+
+
+def test_mixed_valid_and_invalid() -> None:
+    """Test that an error is raised even when some items are valid."""
+    with pytest.raises(TypeError):
+        _collect_args((1, 2, "invalid", 3), int, "int")
+
+
+def test_error_in_middle_of_sequence() -> None:
+    """Test an error is raised when an invalid item is in the middle of a sequence."""
+    with pytest.raises(
+        TypeError,
+        match=r"All items in a sequence must be int objects, got str\.",
+    ):
+        _collect_args(([1, 2, "invalid", 4, 5],), int, "int")  # type: ignore[list-item]
+
+
+def test_custom_type_name_in_error() -> None:
+    """Test that the custom type name appears in error messages."""
+
+    class CustomClass:
+        pass
+
+    with pytest.raises(
+        TypeError,
+        match=(
+            r"Arguments must be CustomType objects or sequences of CustomType objects"
+        ),
+    ):
+        _collect_args(("invalid",), CustomClass, "CustomType")
+
+
+def test_nested_sequences() -> None:
+    """Test that nested sequences are flattened one level."""
+    # Only the outer sequence should be unpacked, not nested ones
+    inner_list = [1, 2]
+    args = ([inner_list, 3],)
+
+    # This should raise an error because inner_list is not an int
+    with pytest.raises(
+        TypeError,
+        match=r"All items in a sequence must be int objects, got list\.",
+    ):
+        _collect_args(args, int, "int")  # type: ignore[arg-type]
+
+
+def test_with_range() -> None:
+    """Test that range objects work as sequences."""
+    args = (range(1, 4),)
+    result = _collect_args(args, int, "int")
+    assert result == [1, 2, 3]

--- a/tests/vaxflux_model_class/test_add_dates.py
+++ b/tests/vaxflux_model_class/test_add_dates.py
@@ -161,17 +161,6 @@ from vaxflux.dates import DateRange
             2,
         ),
     ],
-    ids=[
-        "single_date_range",
-        "multiple_date_ranges_as_args",
-        "list_of_date_ranges",
-        "tuple_of_date_ranges",
-        "mixed_args_and_sequences",
-        "empty_call",
-        "empty_list",
-        "adjacent_date_ranges_no_overlap",
-        "different_seasons_non_overlapping",
-    ],
 )
 def test_add_dates_input_variations(args_factory: object, expected_count: int) -> None:
     """Test adding date ranges with various input patterns."""
@@ -218,49 +207,6 @@ def test_add_dates_preserves_existing_dates() -> None:
     assert len(model._dates) == 3
     assert model._dates[1] == dr2
     assert model._dates[2] == dr3
-
-
-@pytest.mark.parametrize(
-    "invalid_arg",
-    [
-        "not a date range",
-        123,
-        45.6,
-        {"season": "2023/2024"},
-        None,
-    ],
-)
-def test_add_dates_invalid_type_error(invalid_arg: object) -> None:
-    """Test TypeError is raised when passing invalid types."""
-    model = VaxfluxModel(curve=LogisticCurve())
-
-    with pytest.raises(
-        TypeError,
-        match=r"Arguments must be DateRange objects or sequences of DateRange objects",
-    ):
-        model.add_dates(invalid_arg)  # type: ignore[arg-type]
-
-
-@pytest.mark.parametrize(
-    "invalid_item",
-    ["not a date range", 123, {"key": "value"}],
-    ids=["string", "int", "dict"],
-)
-def test_add_dates_sequence_with_invalid_items(invalid_item: object) -> None:
-    """Test TypeError is raised when a sequence contains non-DateRange items."""
-    model = VaxfluxModel(curve=LogisticCurve())
-    dr = DateRange(
-        season="2023/2024",
-        start_date=date(2023, 12, 1),
-        end_date=date(2023, 12, 7),
-        report_date=date(2023, 12, 8),
-    )
-
-    with pytest.raises(
-        TypeError,
-        match=r"All items in a sequence must be DateRange objects",
-    ):
-        model.add_dates([dr, invalid_item])  # type: ignore[list-item]
 
 
 def test_add_dates_exact_duplicate_in_single_call() -> None:
@@ -418,14 +364,6 @@ def test_add_dates_exact_duplicate_across_calls() -> None:
             ),
             r"Overlapping date ranges found: existing '2023/2024'",
         ),
-    ],
-    ids=[
-        "partial_overlap_single_call",
-        "complete_containment",
-        "same_dates_different_report",
-        "single_day_overlap",
-        "different_seasons_overlapping",
-        "overlap_with_existing",
     ],
 )
 def test_add_dates_overlapping_errors(

--- a/tests/vaxflux_model_class/test_add_seasons.py
+++ b/tests/vaxflux_model_class/test_add_seasons.py
@@ -150,17 +150,6 @@ from vaxflux.dates import SeasonRange
             3,
         ),
     ],
-    ids=[
-        "single_season",
-        "multiple_seasons_as_args",
-        "list_of_seasons",
-        "tuple_of_seasons",
-        "mixed_args_and_sequences",
-        "empty_call",
-        "empty_list",
-        "adjacent_seasons_no_overlap",
-        "non_sequential_non_overlapping",
-    ],
 )
 def test_add_seasons_input_variations(
     args_factory: object, expected_count: int
@@ -219,50 +208,6 @@ def test_add_seasons_method_chaining() -> None:
     assert len(model._seasons) == 2
     assert model._seasons[0] == season1
     assert model._seasons[1] == season2
-
-
-@pytest.mark.parametrize(
-    "invalid_arg",
-    [
-        "not a season",
-        123,
-        45.6,
-        {"season": "2023/2024"},
-        None,
-    ],
-)
-def test_add_seasons_invalid_type_error(invalid_arg: object) -> None:
-    """Test TypeError is raised when passing invalid types."""
-    model = VaxfluxModel(curve=LogisticCurve())
-
-    with pytest.raises(
-        TypeError,
-        match=(
-            r"Arguments must be SeasonRange objects or sequences of SeasonRange objects"
-        ),
-    ):
-        model.add_seasons(invalid_arg)  # type: ignore[arg-type]
-
-
-@pytest.mark.parametrize(
-    "invalid_item",
-    ["not a season", 123, {"key": "value"}],
-    ids=["string", "int", "dict"],
-)
-def test_add_seasons_sequence_with_invalid_items(invalid_item: object) -> None:
-    """Test TypeError is raised when a sequence contains non-SeasonRange items."""
-    model = VaxfluxModel(curve=LogisticCurve())
-    season = SeasonRange(
-        season="2023/2024",
-        start_date=date(2023, 12, 1),
-        end_date=date(2024, 3, 31),
-    )
-
-    with pytest.raises(
-        TypeError,
-        match=r"All items in a sequence must be SeasonRange objects",
-    ):
-        model.add_seasons([season, invalid_item])  # type: ignore[list-item]
 
 
 def test_add_seasons_preserves_existing_seasons() -> None:
@@ -365,11 +310,6 @@ def test_add_seasons_preserves_existing_seasons() -> None:
             ),
             r"Season names already exist in the model: \['2023/2024'\]\.",
         ),
-    ],
-    ids=[
-        "single_duplicate_name",
-        "multiple_duplicate_names",
-        "duplicate_with_existing",
     ],
 )
 def test_add_seasons_duplicate_name_errors(
@@ -482,13 +422,6 @@ def test_add_seasons_duplicate_name_errors(
             r"Overlapping date ranges found: '2023/2024' \(2023-12-01 to 2024-03-31\) "
             r"and '2024 Winter' \(2024-03-01 to 2024-05-31\)\.",
         ),
-    ],
-    ids=[
-        "partial_overlap_single_call",
-        "complete_containment",
-        "identical_date_ranges",
-        "single_day_overlap",
-        "overlap_with_existing",
     ],
 )
 def test_add_seasons_overlapping_errors(


### PR DESCRIPTION
Added `VaxfluxModel.add_covariates` and
`VaxfluxModel.add_covariate_categories` methods for adding covariates
and covariate categories to a model. Also:

- Added a numpyro focused `Covariate` ABC with an example implementation
  of `PartiallyPooledGaussianCovariate`.
- Converted `_collect_ranges` into a more general `_collect_args`.
- Removed unnecessary test ids for `@pytest.mark.parameterized`
  decorated tests.

Closes #106.