### PR TITLE
Basic `VaxfluxModel._model` implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ Added:
   [#62](https://github.com/ACCIDDA/vaxflux/issues/62).
 - Added `VaxfluxModel` and new `Curve` classes that are based on
   `jax`/`numpyro`. See [#105](https://github.com/ACCIDDA/vaxflux/issues/105),
-  [#106](https://github.com/ACCIDDA/vaxflux/issues/106).
+  [#106](https://github.com/ACCIDDA/vaxflux/issues/106),
+  [#108](https://github.com/ACCIDDA/vaxflux/issues/108).
 
 Changed:
 

--- a/src/vaxflux/_covariates.py
+++ b/src/vaxflux/_covariates.py
@@ -3,7 +3,7 @@ from typing import cast
 
 import numpyro
 import numpyro.distributions as dist
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from vaxflux._types import NumericalArrayLike
 
@@ -28,7 +28,7 @@ class Covariate(ABC, BaseModel):
         Returns:
             The prefix string derived from the parameter name.
         """
-        return self.parameter + (f"_{self.covariate}" if self.covariate else "")
+        return self.parameter + (f"_{self.covariate}" if self.covariate else "_season")
 
     def presample(self) -> None:
         """
@@ -46,6 +46,24 @@ class Covariate(ABC, BaseModel):
             A numerical array-like structure containing the sampled covariate values.
         """
         raise NotImplementedError
+
+    @field_validator("covariate", mode="after")
+    @classmethod
+    def _covariate_cannot_be_called_season(cls, v: str) -> str:
+        """
+        Validate that the covariate name is not 'season'.
+
+        Args:
+            v: The covariate name to validate.
+
+        Returns:
+            The validated covariate name.
+
+        """
+        if v == "season":
+            msg = "covariate cannot be called 'season'."
+            raise ValueError(msg)
+        return v
 
 
 class PartiallyPooledGaussianCovariate(Covariate):

--- a/src/vaxflux/_curves.py
+++ b/src/vaxflux/_curves.py
@@ -12,12 +12,37 @@ from vaxflux._types import NumericalArrayLike
 
 
 class Curve(ABC):
-    """Abstract class for implementations of uptake curves."""
+    """
+    Abstract class for implementations of uptake curves.
+
+    Attributes:
+        parameters: A tuple of parameter names required by the prevalence function.
+
+    Examples:
+        >>> import jax.numpy as jnp
+        >>> from vaxflux import Curve
+        >>> class ClampedSlopeCurve(Curve):
+        ...     def prevalence(
+        ...         self, t: NumericalArrayLike, m: NumericalArrayLike
+        ...     ) -> jax.Array:
+        ...         return jnp.clip(t * m, 0.0, 1.0)
+        >>> t = jnp.linspace(-1.0, 3.0, num=8)
+        >>> curve = ClampedSlopeCurve()
+        >>> curve.parameters
+        ('m',)
+        >>> curve.prevalence(t, m=0.5)
+        Array([0.        , 0.        , 0.0714286 , 0.35714293, 0.6428572 ,
+               0.9285715 , 1.        , 1.        ], dtype=float32)
+        >>> curve.incidence(t, m=0.5)
+        Array([0. , 0. , 0.5, 0.5, 0.5, 0.5, 0. , 0. ], dtype=float32)
+
+    """
+
+    parameters: tuple[str, ...]
 
     def __init__(self) -> None:
-        in_axes = (0,) + (None,) * (
-            len(inspect.signature(self.prevalence).parameters) - 1
-        )
+        self.parameters = tuple(inspect.signature(self.prevalence).parameters)[1:]
+        in_axes = (0,) + (None,) * len(self.parameters)
         self._grad_prevalence = jax.vmap(jax.grad(self.prevalence), in_axes=in_axes)
 
     @abstractmethod

--- a/src/vaxflux/_vaxflux_model.py
+++ b/src/vaxflux/_vaxflux_model.py
@@ -1,7 +1,9 @@
 __all__: list[str] = []
 
-from typing import Any, Self
+import itertools
+from typing import Any, Self, cast
 
+import jax.numpy as jnp
 import numpyro
 from jax.random import key
 from numpyro.infer import MCMC, NUTS
@@ -229,5 +231,152 @@ class VaxfluxModel:
         with numpyro.handlers.seed(numpyro.handlers.trace(self._model), self._rng_key):
             self._mcmc.run(self._rng_key, num_warmup=warmup, num_samples=samples)
 
+    def _pre_model(self) -> None:
+        """
+        Prepare the model by setting up necessary attributes.
+
+        This method should be called before the model is run as it sets up the
+        necessary attributes for the model to run correctly.
+
+        """
+        self._season_names = [season.season for season in self._seasons]
+        self._season_name_indices = {
+            name: idx for idx, name in enumerate(self._season_names)
+        }
+        self._covariate_categories_map = {
+            category.covariate: category.categories
+            for category in self._covariate_categories
+        }
+        self._covariate_names = list(self._covariate_categories_map.keys())
+        self._covariate_name_indices = {
+            name: idx for idx, name in enumerate(self._covariate_names)
+        }
+        self._covariate_category_indices = {
+            name: {category: idx for idx, category in enumerate(categories)}
+            for name, categories in self._covariate_categories_map.items()
+        }
+        self._category_combinations = (
+            list(
+                itertools.product(
+                    *[
+                        self._covariate_categories_map[name]
+                        for name in self._covariate_names
+                    ]
+                )
+            )
+            if self._covariate_names
+            else [()]
+        )
+        self._covariates_by_parameter = {
+            param: [cov for cov in self._covariates if cov.parameter == param]
+            for param in self._curve.parameters
+        }
+
     def _model(self) -> None:
-        raise NotImplementedError
+        """Define the model for inference."""
+        covariate_values = self._model_sample_covariates()
+        self._model_summed_parameters(covariate_values)
+
+    def _model_sample_covariate(self, covariate: Covariate) -> jnp.ndarray:
+        """
+        Sample from a single covariate.
+
+        Args:
+            covariate: The covariate to sample from.
+
+        Returns:
+            The sampled covariate values.
+        """
+        covariate_categories: list[str]
+        if covariate.covariate is None:
+            # If the covariate does not have a covariate name, it is a seasonal
+            # covariate, so we use the season names as the categories.
+            covariate_categories = self._season_names
+            plate_size = len(covariate_categories)
+        else:
+            # If the covariate has a covariate name, we look up the categories
+            # from the map of covariate categories.
+            possible_covariate_categories = self._covariate_categories_map.get(
+                covariate.covariate
+            )
+            if possible_covariate_categories is None:
+                msg = (
+                    f"Covariate categories for '{covariate.covariate}' not found. "
+                    "Ensure matching covariate categories are added to the model."
+                )
+                raise ValueError(msg)
+            covariate_categories = list(possible_covariate_categories)
+            plate_size = len(covariate_categories) - 1
+        # Sample from the covariate and store the sampled values in a
+        # deterministic site.
+        covariate.presample()
+        with numpyro.plate(f"covariate_{covariate.prefix}", plate_size):
+            sampled_values = covariate.sample()
+        return cast(
+            "jnp.ndarray",
+            numpyro.deterministic(
+                f"covariate_values_{covariate.prefix}",
+                jnp.pad(sampled_values, (1, 0), mode="empty"),
+            ),
+        )
+
+    def _model_sample_covariates(self) -> dict[str, jnp.ndarray]:
+        """
+        Sample from all covariates.
+
+        Returns:
+            A dictionary mapping covariate prefixes to their sampled values.
+        """
+        # Loop over the covariates and sample from them
+        covariate_values: dict[str, jnp.ndarray] = {}
+        for covariate in self._covariates:
+            covariate_values[covariate.prefix] = self._model_sample_covariate(covariate)
+        return covariate_values
+
+    def _model_summed_parameters(
+        self, covariate_values: dict[str, jnp.ndarray]
+    ) -> dict[tuple[str, str, tuple[str, ...]], jnp.ndarray]:
+        """
+        Calculate the summed parameters for parameter/season/covariate categories.
+
+        Args:
+            covariate_values: A dictionary mapping covariate prefixes to their sampled
+                values.
+
+        Returns:
+            A dictionary mapping (parameter, season, covariate-category combo) tuples
+            to their summed covariate effects.
+        """
+        # Now calculate the sums of the covariate values for all of the categories
+        # Keys are (parameter, season, covariate-category combo) and values are the
+        # summed covariate effects for that combination.
+        summed_parameters: dict[tuple[str, str, tuple[str, ...]], jnp.ndarray] = {}
+        for param in self._curve.parameters:
+            for season in self._season_names:
+                for category_combo in self._category_combinations:
+                    # Collect covariate components that apply to this parameter,
+                    # season, and covariate-category combination.
+                    components = []
+                    for covariate in self._covariates_by_parameter.get(param, []):
+                        values = covariate_values[covariate.prefix]
+                        if covariate.covariate is None:
+                            # Seasonal covariates are indexed by season.
+                            season_index = self._season_name_indices[season] + 1
+                            components.append(values[season_index])
+                            continue
+                        # Non-seasonal covariates are indexed by category.
+                        category = category_combo[
+                            self._covariate_name_indices[covariate.covariate]
+                        ]
+                        category_index = self._covariate_category_indices[
+                            covariate.covariate
+                        ][category]
+                        components.append(values[category_index])
+                    # Sum the components (or use zero when none apply) for this
+                    # parameter/season/category combination.
+                    summed_parameters[(param, season, category_combo)] = (
+                        jnp.sum(jnp.stack(components))
+                        if components
+                        else jnp.asarray(0.0)
+                    )
+        return summed_parameters

--- a/tests/vaxflux_model_class/test__pre_model.py
+++ b/tests/vaxflux_model_class/test__pre_model.py
@@ -1,0 +1,128 @@
+"""Unit tests for the `VaxfluxModel._pre_model` method."""
+
+from collections.abc import Callable
+from datetime import date
+from typing import Any
+
+import jax.numpy as jnp
+import pytest
+
+from vaxflux import Curve, PartiallyPooledGaussianCovariate, VaxfluxModel
+from vaxflux._types import NumericalArrayLike
+from vaxflux.covariates import CovariateCategories
+from vaxflux.dates import SeasonRange
+
+
+class DummyCurve(Curve):
+    """Simple dummy curve for testing."""
+
+    parameters = ("m", "r")
+
+    def prevalence(  # type: ignore[override]
+        self, t: NumericalArrayLike, m: NumericalArrayLike, r: NumericalArrayLike
+    ) -> NumericalArrayLike:
+        """Compute the prevalence at time `t`."""
+        return jnp.clip(m * (t - r), 0.0, 1.0)
+
+
+@pytest.mark.parametrize(
+    ("model_factory", "expected"),
+    [
+        (
+            lambda: VaxfluxModel(curve=DummyCurve())
+            .add_seasons(
+                SeasonRange(
+                    season="2023/2024",
+                    start_date=date(2023, 12, 1),
+                    end_date=date(2024, 3, 31),
+                ),
+                SeasonRange(
+                    season="2024/2025",
+                    start_date=date(2024, 12, 1),
+                    end_date=date(2025, 3, 31),
+                ),
+            )
+            .add_covariate_categories(
+                CovariateCategories(covariate="sex", categories=("female", "male"))
+            )
+            .add_covariates(
+                PartiallyPooledGaussianCovariate(
+                    parameter="m",
+                    covariate=None,
+                    mu=(0.0, 0.0),
+                    sigma=1.0,
+                ),
+                PartiallyPooledGaussianCovariate(
+                    parameter="m",
+                    covariate="sex",
+                    mu=(0.0, 1.0),
+                    sigma=1.0,
+                ),
+                PartiallyPooledGaussianCovariate(
+                    parameter="r",
+                    covariate=None,
+                    mu=(0.0, 1.0),
+                    sigma=1.0,
+                ),
+            ),
+            {
+                "season_names": ["2023/2024", "2024/2025"],
+                "season_name_indices": {"2023/2024": 0, "2024/2025": 1},
+                "covariate_categories_map": {"sex": ("female", "male")},
+                "covariate_names": ["sex"],
+                "covariate_name_indices": {"sex": 0},
+                "covariate_category_indices": {"sex": {"female": 0, "male": 1}},
+                "category_combinations": [("female",), ("male",)],
+                "covariates_by_parameter": {
+                    "m": ["m_season", "m_sex"],
+                    "r": ["r_season"],
+                },
+            },
+        ),
+        (
+            lambda: VaxfluxModel(curve=DummyCurve())
+            .add_seasons(
+                SeasonRange(
+                    season="2023/2024",
+                    start_date=date(2023, 12, 1),
+                    end_date=date(2024, 3, 31),
+                ),
+            )
+            .add_covariates(
+                PartiallyPooledGaussianCovariate(
+                    parameter="m",
+                    covariate=None,
+                    mu=(0.0, 1.0),
+                    sigma=1.0,
+                ),
+            ),
+            {
+                "season_names": ["2023/2024"],
+                "season_name_indices": {"2023/2024": 0},
+                "covariate_categories_map": {},
+                "covariate_names": [],
+                "covariate_name_indices": {},
+                "covariate_category_indices": {},
+                "category_combinations": [()],
+                "covariates_by_parameter": {"m": ["m_season"], "r": []},
+            },
+        ),
+    ],
+)
+def test_sets_expected_attributes(
+    model_factory: Callable[[], VaxfluxModel], expected: dict[str, Any]
+) -> None:
+    """Test that `_pre_model` sets the expected attributes."""
+    model = model_factory()
+    model._pre_model()
+    assert model._season_names == expected["season_names"]
+    assert model._season_name_indices == expected["season_name_indices"]
+    assert model._covariate_categories_map == expected["covariate_categories_map"]
+    assert model._covariate_names == expected["covariate_names"]
+    assert model._covariate_name_indices == expected["covariate_name_indices"]
+    assert model._covariate_category_indices == expected["covariate_category_indices"]
+    assert model._category_combinations == expected["category_combinations"]
+    assert {
+        k: [v.prefix for v in model._covariates_by_parameter.get(k, [])]
+        for k in model._covariates_by_parameter
+    } == expected["covariates_by_parameter"]


### PR DESCRIPTION
Added a basic implementation of `VaxfluxModel._model` that currently
samples from the user provided covariates and then calculates the summed
parameters. This implementation has been done by adding functionality to
`VaxfluxModel._model_*` methods that allow for advanced users to
override and modify model construction. Also made the following minor
changes:

- Covariates can no longer correspond to a name of 'season', rather
  users should specify `None`.
- Added a doctest to the `vaxflux.Curve` class to enhance user
  documentation.
- Added a `parameters` attribute to the `Curve` class that is populated
  by `__init__` by dynamically inspecting the `prevalence` method.
- Flushed out `_pre_model` method for constructing easily indexable data
  structures including unit tests.

Closes #108.