### PR TITLE
Add `VaxfluxModel.add_observations` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,8 @@ Added:
   [#14](https://github.com/ACCIDDA/vaxflux/issues/14),
   [#62](https://github.com/ACCIDDA/vaxflux/issues/62).
 - Added `VaxfluxModel` and new `Curve` classes that are based on
-  `jax`/`numpyro`. See [#105](https://github.com/ACCIDDA/vaxflux/issues/105),
-  [#106](https://github.com/ACCIDDA/vaxflux/issues/106),
-  [#108](https://github.com/ACCIDDA/vaxflux/issues/108).
+  `jax`/`numpyro`. See the
+  [Model Refactor milestone](https://github.com/ACCIDDA/vaxflux/milestone/3).
 
 Changed:
 

--- a/src/vaxflux/_vaxflux_model.py
+++ b/src/vaxflux/_vaxflux_model.py
@@ -6,13 +6,18 @@ from typing import Any, Self, cast
 
 import jax.numpy as jnp
 import numpyro
+import pandas as pd
 from jax import Array as JaxArray
 from jax.random import key
 from numpyro.infer import MCMC, NUTS, Predictive
 
 from vaxflux._covariates import Covariate
 from vaxflux._curves import Curve
-from vaxflux._util import _collect_args, _coord_name
+from vaxflux._util import (
+    _collect_args,
+    _coord_name,
+    _validate_and_format_observations,
+)
 from vaxflux.covariates import CovariateCategories
 from vaxflux.dates import (
     DateRange,
@@ -36,6 +41,7 @@ class VaxfluxModel:
         self._dates: list[DateRange] = []
         self._covariate_categories: list[CovariateCategories] = []
         self._covariates: list[Covariate] = []
+        self._observations: pd.DataFrame | None = None
 
     def add_seasons(self, *args: SeasonRange | list[SeasonRange]) -> Self:
         """
@@ -206,6 +212,26 @@ class VaxfluxModel:
         """  # noqa: E501
         covariates = _collect_args(args, Covariate, "Covariate")  # type: ignore[type-abstract]
         self._covariates.extend(covariates)
+        return self
+
+    def add_observations(self, observations: pd.DataFrame) -> Self:
+        """
+        Add observations to the model.
+
+        Args:
+            observations: The observations to add to the model.
+
+        Returns:
+            The model instance for method chaining.
+
+        Raises:
+            ValueError: If observations were already added to the model.
+
+        """
+        if self._observations is not None:
+            msg = "Observations have already been added to the model."
+            raise ValueError(msg)
+        self._observations = _validate_and_format_observations(observations)
         return self
 
     def prior_predictive(

--- a/tests/vaxflux_model_class/test_add_observations.py
+++ b/tests/vaxflux_model_class/test_add_observations.py
@@ -1,0 +1,40 @@
+"""Unit tests for the `VaxfluxModel.add_observations` method."""
+
+from datetime import date
+
+import pandas as pd
+import pytest
+
+from vaxflux._curves import LogisticCurve
+from vaxflux._vaxflux_model import VaxfluxModel
+
+
+def test_add_observations_raises_when_already_set() -> None:
+    """Adding observations twice raises a `ValueError`."""
+    observations = pd.DataFrame.from_records(
+        [
+            {
+                "season": "2022 thru 2023",
+                "start_date": date(2022, 1, 1),
+                "end_date": date(2022, 1, 31),
+                "report_date": date(2022, 2, 1),
+                "type": "incidence",
+                "value": 0.2,
+            },
+            {
+                "season": "2022 thru 2023",
+                "start_date": date(2022, 2, 1),
+                "end_date": date(2022, 2, 28),
+                "report_date": date(2022, 3, 1),
+                "type": "incidence",
+                "value": 0.3,
+            },
+        ],
+    )
+    model = VaxfluxModel(curve=LogisticCurve())
+    model.add_observations(observations)
+    with pytest.raises(
+        ValueError,
+        match=r"^Observations have already been added to the model\.$",
+    ):
+        model.add_observations(observations)


### PR DESCRIPTION
Added the `add_observations` method to add a pandas DataFrame of observations to a `VaxfluxModel`, along with light unit tests.

Closes #126.