### PR TITLE
Add interventions and implementations

### DIFF
--- a/demos/synthetic-data.ipynb
+++ b/demos/synthetic-data.ipynb
@@ -265,7 +265,7 @@
     "                    ),\n",
     "                )\n",
     "\n",
-    "pprint(params)  # noqa: T203"
+    "pprint(params)"
    ]
   },
   {

--- a/demos/vaxflux-model.ipynb
+++ b/demos/vaxflux-model.ipynb
@@ -2,12 +2,16 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "414dd1ae",
    "metadata": {},
    "outputs": [],
    "source": [
+    "from pprint import pprint\n",
+    "\n",
     "from vaxflux import (\n",
+    "    Implementation,\n",
+    "    Intervention,\n",
     "    LogisticCurve,\n",
     "    PartiallyPooledGaussianCovariate,\n",
     "    VaxfluxModel,\n",
@@ -85,16 +89,49 @@
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "7fb27b941602401d91542211134fc71a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "interventions = [\n",
+    "    Intervention(\n",
+    "        name=\"tv_ads\",\n",
+    "        parameter=\"m\",\n",
+    "        distribution=\"Normal\",\n",
+    "        distribution_kwargs={\"loc\": 0.0, \"scale\": 0.1},\n",
+    "    ),\n",
+    "]\n",
+    "implementations = [\n",
+    "    Implementation(\n",
+    "        intervention=\"tv_ads\",\n",
+    "        season=\"2023/24\",\n",
+    "        start_date=\"2023-10-15\",\n",
+    "        end_date=\"2023-11-15\",\n",
+    "        covariate_categories={\"age\": \"adult\"},\n",
+    "    ),\n",
+    "    Implementation(\n",
+    "        intervention=\"tv_ads\",\n",
+    "        season=\"2024/25\",\n",
+    "        start_date=\"2024-11-01\",\n",
+    "        end_date=\"2024-12-01\",\n",
+    "        covariate_categories=None,\n",
+    "    ),\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
    "id": "f2a4731a",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<vaxflux._vaxflux_model.VaxfluxModel at 0x33b6bc650>"
+       "<vaxflux._vaxflux_model.VaxfluxModel at 0x14fbbbdd0>"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -107,13 +144,15 @@
     "    .add_dates(dates)\n",
     "    .add_covariate_categories(age_covariate_categories)\n",
     "    .add_covariates(covariates)\n",
+    "    .add_interventions(interventions)\n",
+    "    .add_implementations(implementations)\n",
     ")\n",
     "model"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "16f33a3e",
    "metadata": {},
    "outputs": [
@@ -125,15 +164,25 @@
       " 'covariate_values_m_season',\n",
       " 'covariate_values_r_season',\n",
       " 'covariate_values_s_season',\n",
+      " 'intervention_tv_ads_implementations',\n",
       " 'm_2022_23_age_adult',\n",
+      " 'm_2022_23_age_adult_daily',\n",
       " 'm_2022_23_age_elderly',\n",
+      " 'm_2022_23_age_elderly_daily',\n",
       " 'm_2022_23_age_youth',\n",
+      " 'm_2022_23_age_youth_daily',\n",
       " 'm_2023_24_age_adult',\n",
+      " 'm_2023_24_age_adult_daily',\n",
       " 'm_2023_24_age_elderly',\n",
+      " 'm_2023_24_age_elderly_daily',\n",
       " 'm_2023_24_age_youth',\n",
+      " 'm_2023_24_age_youth_daily',\n",
       " 'm_2024_25_age_adult',\n",
+      " 'm_2024_25_age_adult_daily',\n",
       " 'm_2024_25_age_elderly',\n",
+      " 'm_2024_25_age_elderly_daily',\n",
       " 'm_2024_25_age_youth',\n",
+      " 'm_2024_25_age_youth_daily',\n",
       " 'm_age',\n",
       " 'm_age_mu',\n",
       " 'm_age_sigma',\n",
@@ -141,26 +190,44 @@
       " 'm_season_mu',\n",
       " 'm_season_sigma',\n",
       " 'r_2022_23_age_adult',\n",
+      " 'r_2022_23_age_adult_daily',\n",
       " 'r_2022_23_age_elderly',\n",
+      " 'r_2022_23_age_elderly_daily',\n",
       " 'r_2022_23_age_youth',\n",
+      " 'r_2022_23_age_youth_daily',\n",
       " 'r_2023_24_age_adult',\n",
+      " 'r_2023_24_age_adult_daily',\n",
       " 'r_2023_24_age_elderly',\n",
+      " 'r_2023_24_age_elderly_daily',\n",
       " 'r_2023_24_age_youth',\n",
+      " 'r_2023_24_age_youth_daily',\n",
       " 'r_2024_25_age_adult',\n",
+      " 'r_2024_25_age_adult_daily',\n",
       " 'r_2024_25_age_elderly',\n",
+      " 'r_2024_25_age_elderly_daily',\n",
       " 'r_2024_25_age_youth',\n",
+      " 'r_2024_25_age_youth_daily',\n",
       " 'r_season',\n",
       " 'r_season_mu',\n",
       " 'r_season_sigma',\n",
       " 's_2022_23_age_adult',\n",
+      " 's_2022_23_age_adult_daily',\n",
       " 's_2022_23_age_elderly',\n",
+      " 's_2022_23_age_elderly_daily',\n",
       " 's_2022_23_age_youth',\n",
+      " 's_2022_23_age_youth_daily',\n",
       " 's_2023_24_age_adult',\n",
+      " 's_2023_24_age_adult_daily',\n",
       " 's_2023_24_age_elderly',\n",
+      " 's_2023_24_age_elderly_daily',\n",
       " 's_2023_24_age_youth',\n",
+      " 's_2023_24_age_youth_daily',\n",
       " 's_2024_25_age_adult',\n",
+      " 's_2024_25_age_adult_daily',\n",
       " 's_2024_25_age_elderly',\n",
+      " 's_2024_25_age_elderly_daily',\n",
       " 's_2024_25_age_youth',\n",
+      " 's_2024_25_age_youth_daily',\n",
       " 's_season',\n",
       " 's_season_mu',\n",
       " 's_season_sigma']\n"
@@ -168,7 +235,8 @@
     }
    ],
    "source": [
-    "prior_predictive = model.prior_predictive(samples=150)"
+    "prior_predictive = model.prior_predictive(samples=150)\n",
+    "pprint(list(prior_predictive.keys()))"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,10 @@ allow-star-arg-any = true
 max-complexity = 12  # Default is 10
 
 [tool.ruff.lint.per-file-ignores]
+"demos/**/*" = [
+    "T201",   # `print` found
+    "T203",   # `pprint` found
+]
 "docs/**/*" = [
     "INP001", # Implicit namespace package
 ]

--- a/src/vaxflux/__init__.py
+++ b/src/vaxflux/__init__.py
@@ -3,6 +3,8 @@
 __all__ = (
     "Covariate",
     "Curve",
+    "Implementation",
+    "Intervention",
     "LogisticCurve",
     "PartiallyPooledGaussianCovariate",
     "VaxfluxModel",
@@ -26,4 +28,5 @@ from vaxflux import (
 )
 from vaxflux._covariates import Covariate, PartiallyPooledGaussianCovariate
 from vaxflux._curves import Curve, LogisticCurve
+from vaxflux._interventions import Implementation, Intervention
 from vaxflux._vaxflux_model import VaxfluxModel

--- a/src/vaxflux/_interventions.py
+++ b/src/vaxflux/_interventions.py
@@ -1,0 +1,179 @@
+"""Intervention definitions for numpyro/JAX models."""
+
+import warnings
+from datetime import date
+from typing import Annotated, Any, cast
+
+import numpyro
+import numpyro.distributions as dist
+from jax import Array as JaxArray
+from pydantic import BaseModel, ConfigDict, Field, computed_field
+
+from vaxflux._util import _coord_name
+from vaxflux.covariates import CovariateCategories, _covariate_categories_to_dict
+from vaxflux.dates import SeasonRange
+
+InterventionName = Annotated[str, Field(pattern=r"^[a-z0-9_]+$")]
+
+
+class Intervention(BaseModel):
+    """A representation for the affect of an intervention on the uptake of a vaccine."""
+
+    model_config = ConfigDict(frozen=True)
+
+    #: The name of the intervention, must be a lowercase alphanumeric string.
+    name: InterventionName
+
+    #: The name of the parameter this intervention affects.
+    parameter: str
+
+    #: The name of the distribution to use for the intervention.
+    distribution: str
+
+    #: The keyword arguments to pass to the distribution. Must be a dictionary of
+    #: strings to values.
+    distribution_kwargs: dict[str, Any]
+
+    def numpyro_distribution(self) -> dist.Distribution:
+        """Return a numpyro distribution for the intervention."""
+        return getattr(dist, self.distribution)(**self.distribution_kwargs)
+
+    def sample(self, name: str) -> JaxArray:
+        """Sample an intervention effect from its distribution."""
+        return cast("JaxArray", numpyro.sample(name, self.numpyro_distribution()))
+
+
+class Implementation(BaseModel):
+    """A representation of an implementation of an intervention."""
+
+    model_config = ConfigDict(frozen=True)
+
+    #: The name of the intervention being implemented.
+    intervention: InterventionName
+
+    #: The season this implementation applies to.
+    season: str
+
+    #: The start date of the implementation or `None` if to apply from the start of the
+    #: season.
+    start_date: date | None
+
+    #: The end date of the implementation or `None` if to apply to the end of the
+    #: season.
+    end_date: date | None
+
+    #: The covariate categories this implementation applies to in the format
+    #: `{covariate: category}`. If `None`, applies to all covariate categories.
+    covariate_categories: dict[str, str] | None
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def name(self) -> str:
+        """
+        Get the name of the implementation.
+
+        Returns:
+            The name of the implementation, formatted as a string.
+        """
+        return _coord_name(
+            *[
+                self.intervention,
+                self.season,
+                *[
+                    str(item)
+                    for k in sorted((self.covariate_categories or {}).keys())
+                    for item in [k, self.covariate_categories[k]]  # type: ignore[index]
+                ],
+            ],
+        )
+
+
+def _check_interventions_and_implementations(
+    interventions: list[Intervention],
+    implementations: list[Implementation],
+    season_ranges: list[SeasonRange],
+    covariate_categories: list[CovariateCategories],
+) -> None:
+    """Check that the interventions and implementations are valid."""
+    intervention_names = {i.name for i in interventions}
+    implementation_intervention_names = {i.intervention for i in implementations}
+    if (
+        len(
+            missing_intervention_names := implementation_intervention_names
+            - intervention_names,
+        )
+        > 0
+    ):
+        msg = (
+            "The following implementation intervention names do not match "
+            f"any interventions: {', '.join(missing_intervention_names)}."
+        )
+        raise ValueError(
+            msg,
+        )
+    if (
+        len(
+            missing_implementation_names := intervention_names
+            - implementation_intervention_names,
+        )
+        > 0
+    ):
+        warnings.warn(
+            f"The following interventions do not have a corresponding implementation, "
+            f"affect will be unknown: {', '.join(missing_implementation_names)}.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+    season_map = {season.season: season for season in season_ranges}
+    implementation_seasons = {i.season for i in implementations}
+    if len(missing_season_names := implementation_seasons - season_map.keys()) > 0:
+        msg = (
+            "The following implementation seasons do not match "
+            f"any seasons: {', '.join(missing_season_names)}."
+        )
+        raise ValueError(
+            msg,
+        )
+    for implementation in implementations:
+        if (
+            implementation.start_date is not None
+            and implementation.start_date < season_map[implementation.season].start_date
+        ):
+            msg = (
+                f"The start date of the implementation {implementation} is before "
+                f"the start date of the season {implementation.season}."
+            )
+            raise ValueError(
+                msg,
+            )
+        if (
+            implementation.end_date is not None
+            and implementation.end_date > season_map[implementation.season].end_date
+        ):
+            msg = (
+                f"The end date of the implementation {implementation} is after "
+                f"the end date of the season {implementation.season}."
+            )
+            raise ValueError(
+                msg,
+            )
+    covariate_categories_map = _covariate_categories_to_dict(covariate_categories)
+    for implementation in implementations:
+        if implementation.covariate_categories is not None:
+            for covariate, category in implementation.covariate_categories.items():
+                if covariate not in covariate_categories_map:
+                    msg = (
+                        f"The covariate '{covariate}' is not a valid covariate "
+                        f"category."
+                    )
+                    raise ValueError(
+                        msg,
+                    )
+                if category not in covariate_categories_map[covariate]:
+                    msg = (
+                        f"The category '{category}' is not a valid category for "
+                        f"covariate '{covariate}'."
+                    )
+                    raise ValueError(
+                        msg,
+                    )

--- a/src/vaxflux/_vaxflux_model.py
+++ b/src/vaxflux/_vaxflux_model.py
@@ -13,6 +13,11 @@ from numpyro.infer import MCMC, NUTS, Predictive
 
 from vaxflux._covariates import Covariate
 from vaxflux._curves import Curve
+from vaxflux._interventions import (
+    Implementation,
+    Intervention,
+    _check_interventions_and_implementations,
+)
 from vaxflux._util import (
     _collect_args,
     _coord_name,
@@ -42,6 +47,8 @@ class VaxfluxModel:
         self._covariate_categories: list[CovariateCategories] = []
         self._covariates: list[Covariate] = []
         self._observations: pd.DataFrame | None = None
+        self._interventions: list[Intervention] = []
+        self._implementations: list[Implementation] = []
 
     def add_seasons(self, *args: SeasonRange | list[SeasonRange]) -> Self:
         """
@@ -214,6 +221,46 @@ class VaxfluxModel:
         self._covariates.extend(covariates)
         return self
 
+    def add_interventions(self, *args: Intervention | list[Intervention]) -> Self:
+        """
+        Add one or more interventions to the model.
+
+        Args:
+            *args: One or more `Intervention` objects or sequences of `Intervention`
+                objects.
+
+        Returns:
+            The model instance for method chaining.
+
+        Raises:
+            TypeError: If any argument is not an `Intervention` or a sequence of
+                `Intervention` objects.
+
+        """
+        interventions = _collect_args(args, Intervention, "Intervention")
+        self._interventions.extend(interventions)
+        return self
+
+    def add_implementations(self, *args: Implementation | list[Implementation]) -> Self:
+        """
+        Add one or more implementations to the model.
+
+        Args:
+            *args: One or more `Implementation` objects or sequences of
+                `Implementation` objects.
+
+        Returns:
+            The model instance for method chaining.
+
+        Raises:
+            TypeError: If any argument is not an `Implementation` or a sequence of
+                `Implementation` objects.
+
+        """
+        implementations = _collect_args(args, Implementation, "Implementation")
+        self._implementations.extend(implementations)
+        return self
+
     def add_observations(self, observations: pd.DataFrame) -> Self:
         """
         Add observations to the model.
@@ -296,9 +343,23 @@ class VaxfluxModel:
         necessary attributes for the model to run correctly.
 
         """
+        _check_interventions_and_implementations(
+            self._interventions,
+            self._implementations,
+            self._seasons,
+            self._covariate_categories,
+        )
         self._season_names = [season.season for season in self._seasons]
         self._season_name_indices = {
             name: idx for idx, name in enumerate(self._season_names)
+        }
+        self._season_map = {season.season: season for season in self._seasons}
+        self._season_day_counts = {
+            season.season: (season.end_date - season.start_date).days + 1
+            for season in self._seasons
+        }
+        self._season_tokens = {
+            season_name: _coord_name(season_name) for season_name in self._season_names
         }
         self._covariate_categories_map = {
             category.covariate: category.categories
@@ -328,11 +389,21 @@ class VaxfluxModel:
             param: [cov for cov in self._covariates if cov.parameter == param]
             for param in self._curve.parameters
         }
+        self._interventions_by_name = {
+            intervention.name: [
+                implementation
+                for implementation in self._implementations
+                if implementation.intervention == intervention.name
+            ]
+            for intervention in self._interventions
+        }
 
     def _model(self) -> None:
         """Define the model for inference."""
         covariate_values = self._model_sample_covariates()
-        self._model_summed_parameters(covariate_values)
+        summed_parameters = self._model_summed_parameters(covariate_values)
+        daily_summed_parameters = self._model_daily_summed_parameters(summed_parameters)
+        self._model_apply_interventions(daily_summed_parameters)
 
     def _model_sample_covariate(self, covariate: Covariate) -> jnp.ndarray:
         """
@@ -446,6 +517,107 @@ class VaxfluxModel:
                         else jnp.asarray(0.0),
                     )
         return summed_parameters
+
+    def _model_daily_summed_parameters(
+        self, summed_parameters: dict[str, jnp.ndarray]
+    ) -> dict[str, jnp.ndarray]:
+        """
+        Calculate daily summed parameters for each date range.
+
+        Args:
+            summed_parameters: A dictionary mapping (parameter, season,
+                covariate-category combo) strings to their summed covariate effects.
+
+        Returns:
+            A dictionary mapping daily parameter names to daily summed values.
+
+        """
+        daily_summed_parameters: dict[str, jnp.ndarray] = {}
+        for name, value in summed_parameters.items():
+            matched_season: str | None = None
+            for season_name, season_token in self._season_tokens.items():
+                if f"_{season_token}_" in name or name.endswith(f"_{season_token}"):
+                    matched_season = season_name
+                    break
+            if matched_season is None:
+                msg = f"Could not determine season for summed parameter '{name}'."
+                raise ValueError(msg)
+            daily_name = _coord_name(name, "daily")
+            daily_summed_parameters[daily_name] = numpyro.deterministic(
+                daily_name,
+                jnp.repeat(value, self._season_day_counts[matched_season]),
+            )
+        return daily_summed_parameters
+
+    def _model_apply_interventions(
+        self, daily_summed_parameters: dict[str, jnp.ndarray]
+    ) -> dict[str, jnp.ndarray]:
+        """
+        Apply interventions to daily summed parameters.
+
+        Args:
+            daily_summed_parameters: A dictionary mapping daily parameter names to
+                daily summed values.
+
+        Returns:
+            A dictionary mapping daily parameter names to adjusted values.
+
+        """
+        if not self._interventions or not self._implementations:
+            return daily_summed_parameters
+        updated_parameters = dict(daily_summed_parameters)
+        for intervention in self._interventions:
+            intervention_implementations = self._interventions_by_name.get(
+                intervention.name,
+                [],
+            )
+            if not intervention_implementations:
+                continue
+            plate_name = _coord_name(
+                "intervention",
+                intervention.name,
+                "implementations",
+            )
+            with numpyro.plate(
+                f"{plate_name}_plate", len(intervention_implementations)
+            ):
+                intervention_values = intervention.sample(plate_name)
+            for idx, implementation in enumerate(intervention_implementations):
+                if implementation.season not in self._season_map:
+                    continue
+                season_range = self._season_map[implementation.season]
+                start_date = implementation.start_date or season_range.start_date
+                end_date = implementation.end_date or season_range.end_date
+                start_idx = (start_date - season_range.start_date).days
+                end_idx = (end_date - season_range.start_date).days
+                n_days = (season_range.end_date - season_range.start_date).days + 1
+                mask = (jnp.arange(n_days) >= start_idx) & (
+                    jnp.arange(n_days) <= end_idx
+                )
+                for category_combo in self._category_combinations:
+                    if implementation.covariate_categories is not None:
+                        combo_map = dict(
+                            zip(self._covariate_names, category_combo, strict=False)
+                        )
+                        if not all(
+                            combo_map.get(covariate) == category
+                            for covariate, category in implementation.covariate_categories.items()  # noqa: E501
+                        ):
+                            continue
+                    daily_name = _coord_name(
+                        _coord_name(
+                            intervention.parameter,
+                            implementation.season,
+                            *self._category_combo_with_name(category_combo),
+                        ),
+                        "daily",
+                    )
+                    if daily_name not in updated_parameters:
+                        continue
+                    updated_parameters[daily_name] = (
+                        updated_parameters[daily_name] + intervention_values[idx] * mask
+                    )
+        return updated_parameters
 
     def _category_combo_with_name(
         self, category_combo: tuple[str, ...]

--- a/tests/_interventions/test__check_interventions_and_implementations.py
+++ b/tests/_interventions/test__check_interventions_and_implementations.py
@@ -1,0 +1,258 @@
+"""Unit tests for `_check_interventions_and_implementations`."""
+
+from datetime import date
+
+import pytest
+
+from vaxflux._interventions import (
+    Implementation,
+    Intervention,
+    _check_interventions_and_implementations,
+)
+from vaxflux.covariates import CovariateCategories
+from vaxflux.dates import SeasonRange
+
+
+@pytest.fixture
+def example_inputs() -> tuple[
+    list[Intervention],
+    list[Implementation],
+    list[SeasonRange],
+    list[CovariateCategories],
+]:
+    """
+    Example inputs for testing `_check_interventions_and_implementations`.
+
+    Returns:
+        A tuple containing lists of interventions, implementations, season ranges,
+        and covariate categories for a hypothetical vaccination TV advertisement
+        campaign.
+
+    """
+    interventions = [
+        Intervention(
+            name="tv_ads",
+            parameter="m",
+            distribution="Normal",
+            distribution_kwargs={"loc": 0.0, "scale": 1.0},
+        )
+    ]
+    implementations = [
+        Implementation(
+            intervention="tv_ads",
+            season="2022/23",
+            start_date=None,
+            end_date=None,
+            covariate_categories={"sex": "male"},
+        )
+    ]
+    season_ranges = [
+        SeasonRange(
+            season="2022/23",
+            start_date=date(2022, 1, 1),
+            end_date=date(2022, 12, 31),
+        )
+    ]
+    covariate_categories = [
+        CovariateCategories(covariate="sex", categories=("female", "male"))
+    ]
+    return interventions, implementations, season_ranges, covariate_categories
+
+
+@pytest.mark.parametrize("missing_name", ["radio_ads"])
+def test_missing_intervention_names_raises_value_error(
+    example_inputs: tuple[
+        list[Intervention],
+        list[Implementation],
+        list[SeasonRange],
+        list[CovariateCategories],
+    ],
+    missing_name: str,
+) -> None:
+    """Implementations without matching interventions raise a `ValueError`."""
+    interventions, implementations, season_ranges, covariate_categories = example_inputs
+    implementations = [
+        Implementation(
+            intervention=missing_name,
+            season=implementations[0].season,
+            start_date=implementations[0].start_date,
+            end_date=implementations[0].end_date,
+            covariate_categories=implementations[0].covariate_categories,
+        )
+    ]
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"^The following implementation intervention names do not match "
+            r"any interventions: .*.$"
+        ),
+    ):
+        _check_interventions_and_implementations(
+            interventions,
+            implementations,
+            season_ranges,
+            covariate_categories,
+        )
+
+
+@pytest.mark.parametrize("missing_name", ["radio_ads"])
+def test_missing_implementation_names_warns(
+    example_inputs: tuple[
+        list[Intervention],
+        list[Implementation],
+        list[SeasonRange],
+        list[CovariateCategories],
+    ],
+    missing_name: str,
+) -> None:
+    """Interventions without implementations emit a warning."""
+    interventions, implementations, season_ranges, covariate_categories = example_inputs
+    interventions = [
+        *interventions,
+        Intervention(
+            name=missing_name,
+            parameter="m",
+            distribution="Normal",
+            distribution_kwargs={"loc": 0.0, "scale": 1.0},
+        ),
+    ]
+    with pytest.warns(
+        RuntimeWarning,
+        match=(
+            r"^The following interventions do not have a corresponding "
+            r"implementation, affect will be unknown: .*.$"
+        ),
+    ):
+        _check_interventions_and_implementations(
+            interventions,
+            implementations,
+            season_ranges,
+            covariate_categories,
+        )
+
+
+@pytest.mark.parametrize("missing_season", ["2023/24"])
+def test_missing_season_names_raises_value_error(
+    example_inputs: tuple[
+        list[Intervention],
+        list[Implementation],
+        list[SeasonRange],
+        list[CovariateCategories],
+    ],
+    missing_season: str,
+) -> None:
+    """Implementations with unknown seasons raise a `ValueError`."""
+    interventions, implementations, season_ranges, covariate_categories = example_inputs
+    implementations = [
+        Implementation(
+            intervention=implementations[0].intervention,
+            season=missing_season,
+            start_date=implementations[0].start_date,
+            end_date=implementations[0].end_date,
+            covariate_categories=implementations[0].covariate_categories,
+        )
+    ]
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"^The following implementation seasons do not match "
+            r"any seasons: .*.$"
+        ),
+    ):
+        _check_interventions_and_implementations(
+            interventions,
+            implementations,
+            season_ranges,
+            covariate_categories,
+        )
+
+
+@pytest.mark.parametrize(
+    ("start_date", "end_date", "match"),
+    [
+        (
+            date(2021, 12, 31),
+            None,
+            r"^The start date of the implementation .* is before the start date",
+        ),
+        (
+            None,
+            date(2023, 1, 1),
+            r"^The end date of the implementation .* is after the end date",
+        ),
+    ],
+)
+def test_implementation_date_bounds_raises_value_error(
+    example_inputs: tuple[
+        list[Intervention],
+        list[Implementation],
+        list[SeasonRange],
+        list[CovariateCategories],
+    ],
+    start_date: date | None,
+    end_date: date | None,
+    match: str,
+) -> None:
+    """Implementation dates outside season bounds raise a `ValueError`."""
+    interventions, implementations, season_ranges, covariate_categories = example_inputs
+    implementations = [
+        Implementation(
+            intervention=implementations[0].intervention,
+            season=implementations[0].season,
+            start_date=start_date,
+            end_date=end_date,
+            covariate_categories=implementations[0].covariate_categories,
+        )
+    ]
+    with pytest.raises(ValueError, match=match):
+        _check_interventions_and_implementations(
+            interventions,
+            implementations,
+            season_ranges,
+            covariate_categories,
+        )
+
+
+@pytest.mark.parametrize(
+    ("covariate_categories", "match"),
+    [
+        (
+            {"age": "adult"},
+            r"^The covariate 'age' is not a valid covariate category\.$",
+        ),
+        (
+            {"sex": "other"},
+            r"^The category 'other' is not a valid category for covariate 'sex'\.$",
+        ),
+    ],
+)
+def test_invalid_covariate_categories_raise_value_error(
+    example_inputs: tuple[
+        list[Intervention],
+        list[Implementation],
+        list[SeasonRange],
+        list[CovariateCategories],
+    ],
+    covariate_categories: dict[str, str],
+    match: str,
+) -> None:
+    """Invalid covariate categories raise a `ValueError`."""
+    interventions, implementations, season_ranges, covariate_categories_list = (
+        example_inputs
+    )
+    implementations = [
+        Implementation(
+            intervention=implementations[0].intervention,
+            season=implementations[0].season,
+            start_date=implementations[0].start_date,
+            end_date=implementations[0].end_date,
+            covariate_categories=covariate_categories,
+        )
+    ]
+    with pytest.raises(ValueError, match=match):
+        _check_interventions_and_implementations(
+            interventions,
+            implementations,
+            season_ranges,
+            covariate_categories_list,
+        )


### PR DESCRIPTION
Added `numpyro` based interventions/implementations as well as
`add_interventions`/`add_implementations` methods to `VaxfluxModel` for
adding them to a model.

- Added `vaxflux.Intervention/Implementation` classes for representing a
  type of intervention and implementations of said intervention.
- Added an internal helper, `_check_interventions_and_implementations`
  for validating interventions/implementations against other user
  provided inputs.
- Incorporated interventions and implementations into the model produced
  by `VaxfluxModel` by expanding out summed uptake parameters to a daily
  array and then applying implementations to the relevant days of the
  summed parameters daily arrays.
- Added interventions/implementations to the `vaxflux-model.ipynb` demo
  notebook.

Closes #107.