### PR TITLE
Add checks to adding dates/implementations

### DIFF
--- a/src/vaxflux/_vaxflux_model.py
+++ b/src/vaxflux/_vaxflux_model.py
@@ -50,6 +50,15 @@ class VaxfluxModel:
         self._interventions: list[Intervention] = []
         self._implementations: list[Implementation] = []
 
+    def __repr__(self) -> str:
+        """
+        Return a string representation of the model.
+
+        Returns:
+            A string representation of the `VaxfluxModel` instance.
+        """
+        return f"<vaxflux.VaxfluxModel object at {hex(id(self))}>"
+
     def add_seasons(self, *args: SeasonRange | list[SeasonRange]) -> Self:
         """
         Add one or more seasons to the model.
@@ -69,14 +78,15 @@ class VaxfluxModel:
             >>> from vaxflux._curves import LogisticCurve
             >>> from vaxflux.dates import SeasonRange
             >>> model = VaxfluxModel(curve=LogisticCurve())
-            >>> result = model.add_seasons(
+            >>> model.add_seasons(
             ...     SeasonRange(
             ...         season="2023/2024",
             ...         start_date="2023-12-01",
             ...         end_date="2024-03-31",
             ...     )
             ... )
-            >>> result = model.add_seasons(
+            <vaxflux.VaxfluxModel object at ...>
+            >>> model.add_seasons(
             ...     SeasonRange(
             ...         season="2024/2025",
             ...         start_date="2024-12-01",
@@ -88,7 +98,8 @@ class VaxfluxModel:
             ...         end_date="2026-03-31",
             ...     ),
             ... )
-            >>> result = model.add_seasons(
+            <vaxflux.VaxfluxModel object at ...>
+            >>> model.add_seasons(
             ...     [
             ...         SeasonRange(
             ...             season="2026/2027",
@@ -102,6 +113,7 @@ class VaxfluxModel:
             ...         ),
             ...     ]
             ... )
+            <vaxflux.VaxfluxModel object at ...>
             >>> model.add_seasons("invalid_argument")
             Traceback (most recent call last):
                 ...
@@ -131,9 +143,17 @@ class VaxfluxModel:
 
         Examples:
             >>> from vaxflux._curves import LogisticCurve
-            >>> from vaxflux.dates import DateRange
+            >>> from vaxflux.dates import DateRange, SeasonRange
             >>> model = VaxfluxModel(curve=LogisticCurve())
-            >>> result = model.add_dates(
+            >>> model.add_seasons(
+            ...     SeasonRange(
+            ...         season="2023/2024",
+            ...         start_date="2023-12-01",
+            ...         end_date="2024-03-31",
+            ...     )
+            ... )
+            <vaxflux.VaxfluxModel object at ...>
+            >>> model.add_dates(
             ...     DateRange(
             ...         season="2023/2024",
             ...         start_date="2023-12-01",
@@ -141,6 +161,7 @@ class VaxfluxModel:
             ...         report_date="2023-12-08",
             ...     )
             ... )
+            <vaxflux.VaxfluxModel object at ...>
             >>> model.add_dates("invalid_argument")
             Traceback (most recent call last):
                 ...
@@ -148,6 +169,14 @@ class VaxfluxModel:
 
         """  # noqa: E501
         dates = _collect_ranges(args, DateRange, "DateRange")
+        if missing_seasons := {date.season for date in dates} - {
+            season.season for season in self._seasons
+        }:
+            msg = (
+                "The following date range seasons have not been added "
+                f"to the model: {sorted(missing_seasons)}."
+            )
+            raise ValueError(msg)
         _validate_ranges(dates, self._dates)
         self._dates.extend(dates)
         return self
@@ -194,7 +223,7 @@ class VaxfluxModel:
             >>> from vaxflux._covariates import PartiallyPooledGaussianCovariate
             >>> from vaxflux._curves import LogisticCurve
             >>> model = VaxfluxModel(curve=LogisticCurve())
-            >>> result = model.add_covariates(
+            >>> model.add_covariates(
             ...     PartiallyPooledGaussianCovariate(
             ...         parameter="m",
             ...         covariate="age",
@@ -202,7 +231,8 @@ class VaxfluxModel:
             ...         sigma=0.2,
             ...     )
             ... )
-            >>> result = model.add_covariates(
+            <vaxflux.VaxfluxModel object at ...>
+            >>> model.add_covariates(
             ...     [
             ...         PartiallyPooledGaussianCovariate(
             ...             parameter="sigma",
@@ -211,6 +241,7 @@ class VaxfluxModel:
             ...         ),
             ...     ]
             ... )
+            <vaxflux.VaxfluxModel object at ...>
             >>> model.add_covariates("invalid_argument")
             Traceback (most recent call last):
                 ...
@@ -255,9 +286,19 @@ class VaxfluxModel:
         Raises:
             TypeError: If any argument is not an `Implementation` or a sequence of
                 `Implementation` objects.
+            ValueError: If an implementation's intervention has not been added to the
+                model.
 
         """
         implementations = _collect_args(args, Implementation, "Implementation")
+        if missing_interventions := {
+            implementation.intervention for implementation in implementations
+        } - {intervention.name for intervention in self._interventions}:
+            msg = (
+                "The following implementation interventions have not been added "
+                f"to the model: {sorted(missing_interventions)}."
+            )
+            raise ValueError(msg)
         self._implementations.extend(implementations)
         return self
 

--- a/tests/vaxflux_model_class/test_add_dates.py
+++ b/tests/vaxflux_model_class/test_add_dates.py
@@ -6,14 +6,26 @@ import pytest
 
 from vaxflux._curves import LogisticCurve
 from vaxflux._vaxflux_model import VaxfluxModel
-from vaxflux.dates import DateRange
+from vaxflux.dates import DateRange, SeasonRange
+
+SEASON_2023_2024 = SeasonRange(
+    season="2023/2024",
+    start_date=date(2023, 10, 1),
+    end_date=date(2024, 2, 1),
+)
+SEASON_2024_2025 = SeasonRange(
+    season="2024/2025",
+    start_date=date(2024, 10, 1),
+    end_date=date(2025, 2, 1),
+)
 
 
 @pytest.mark.parametrize(
-    ("args_factory", "expected_count"),
+    ("season_ranges", "args_factory", "expected_count"),
     [
         # Single date range
         (
+            [SEASON_2023_2024],
             lambda: (
                 DateRange(
                     season="2023/2024",
@@ -26,6 +38,7 @@ from vaxflux.dates import DateRange
         ),
         # Multiple date ranges as args
         (
+            [SEASON_2023_2024],
             lambda: (
                 DateRange(
                     season="2023/2024",
@@ -50,6 +63,7 @@ from vaxflux.dates import DateRange
         ),
         # List of date ranges
         (
+            [SEASON_2023_2024],
             lambda: (
                 [
                     DateRange(
@@ -70,6 +84,7 @@ from vaxflux.dates import DateRange
         ),
         # Tuple of date ranges
         (
+            [SEASON_2023_2024],
             lambda: (
                 (
                     DateRange(
@@ -90,6 +105,7 @@ from vaxflux.dates import DateRange
         ),
         # Mixed args and sequences
         (
+            [SEASON_2023_2024],
             lambda: (
                 DateRange(
                     season="2023/2024",
@@ -121,11 +137,12 @@ from vaxflux.dates import DateRange
             4,
         ),
         # Empty call
-        (lambda: (), 0),
+        ([], lambda: (), 0),
         # Empty list
-        (lambda: ([],), 0),
+        ([], lambda: ([],), 0),
         # Adjacent date ranges (no overlap) - end date + 1 = next start date
         (
+            [SEASON_2023_2024],
             lambda: (
                 DateRange(
                     season="2023/2024",
@@ -144,6 +161,7 @@ from vaxflux.dates import DateRange
         ),
         # Non-overlapping date ranges from different seasons
         (
+            [SEASON_2023_2024, SEASON_2024_2025],
             lambda: (
                 DateRange(
                     season="2023/2024",
@@ -162,9 +180,15 @@ from vaxflux.dates import DateRange
         ),
     ],
 )
-def test_add_dates_input_variations(args_factory: object, expected_count: int) -> None:
+def test_add_dates_input_variations(
+    season_ranges: list[SeasonRange],
+    args_factory: object,
+    expected_count: int,
+) -> None:
     """Test adding date ranges with various input patterns."""
     model = VaxfluxModel(curve=LogisticCurve())
+    if season_ranges:
+        model.add_seasons(season_ranges)
     args = args_factory()  # type: ignore[operator]
     result = model.add_dates(*args)
 
@@ -177,6 +201,7 @@ def test_add_dates_input_variations(args_factory: object, expected_count: int) -
 def test_add_dates_preserves_existing_dates() -> None:
     """Test that add_dates preserves previously added date ranges."""
     model = VaxfluxModel(curve=LogisticCurve())
+    model.add_seasons(SEASON_2023_2024)
     dr1 = DateRange(
         season="2023/2024",
         start_date=date(2023, 12, 1),
@@ -212,6 +237,7 @@ def test_add_dates_preserves_existing_dates() -> None:
 def test_add_dates_exact_duplicate_in_single_call() -> None:
     """Test ValueError is raised when duplicate date ranges are in a single call."""
     model = VaxfluxModel(curve=LogisticCurve())
+    model.add_seasons(SEASON_2023_2024)
     dr = DateRange(
         season="2023/2024",
         start_date=date(2023, 12, 1),
@@ -229,6 +255,7 @@ def test_add_dates_exact_duplicate_in_single_call() -> None:
 def test_add_dates_exact_duplicate_across_calls() -> None:
     """Test ValueError is raised when adding an exact duplicate date range."""
     model = VaxfluxModel(curve=LogisticCurve())
+    model.add_seasons(SEASON_2023_2024)
     dr = DateRange(
         season="2023/2024",
         start_date=date(2023, 12, 1),
@@ -373,6 +400,7 @@ def test_add_dates_overlapping_errors(
 ) -> None:
     """Test ValueError is raised for various overlapping date range scenarios."""
     model = VaxfluxModel(curve=LogisticCurve())
+    model.add_seasons(SEASON_2023_2024, SEASON_2024_2025)
 
     # Add setup dates if provided (for testing across calls)
     if setup_dates:
@@ -383,3 +411,22 @@ def test_add_dates_overlapping_errors(
 
     with pytest.raises(ValueError, match=match_pattern):
         model.add_dates(*test_dates)
+
+
+def test_add_dates_raises_when_season_missing() -> None:
+    """Adding date ranges for missing seasons raises a `ValueError`."""
+    model = VaxfluxModel(curve=LogisticCurve())
+    date_range = DateRange(
+        season="2023/2024",
+        start_date=date(2023, 12, 1),
+        end_date=date(2023, 12, 7),
+        report_date=date(2023, 12, 8),
+    )
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"^The following date range seasons have not been added "
+            r"to the model: .*.$"
+        ),
+    ):
+        model.add_dates(date_range)

--- a/tests/vaxflux_model_class/test_add_implementations.py
+++ b/tests/vaxflux_model_class/test_add_implementations.py
@@ -1,0 +1,52 @@
+"""Unit tests for the `VaxfluxModel.add_implementations` method."""
+
+from datetime import date
+
+import pytest
+
+from vaxflux._curves import LogisticCurve
+from vaxflux._interventions import Implementation, Intervention
+from vaxflux._vaxflux_model import VaxfluxModel
+
+
+def test_add_implementations_raises_when_intervention_missing() -> None:
+    """Adding implementations without interventions raises a `ValueError`."""
+    model = VaxfluxModel(curve=LogisticCurve())
+    implementation = Implementation(
+        intervention="tv_ads",
+        season="2023/2024",
+        start_date=date(2023, 12, 1),
+        end_date=date(2023, 12, 31),
+        covariate_categories=None,
+    )
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"^The following implementation interventions have not been added "
+            r"to the model: .*.$"
+        ),
+    ):
+        model.add_implementations(implementation)
+
+
+def test_add_implementations_allows_known_intervention() -> None:
+    """Adding implementations with known interventions succeeds."""
+    model = VaxfluxModel(curve=LogisticCurve())
+    model.add_interventions(
+        Intervention(
+            name="tv_ads",
+            parameter="m",
+            distribution="Normal",
+            distribution_kwargs={"loc": 0.0, "scale": 0.1},
+        )
+    )
+    implementation = Implementation(
+        intervention="tv_ads",
+        season="2023/2024",
+        start_date=date(2023, 12, 1),
+        end_date=date(2023, 12, 31),
+        covariate_categories=None,
+    )
+    result = model.add_implementations(implementation)
+    assert result is model
+    assert model._implementations == [implementation]


### PR DESCRIPTION
Add checks to adding dates/implementations

- Added checks to `VaxfluxModel.add_dates/implementations` to ensure
  that the corresponding seasons/interventions are present already.
- Added a custom `VaxfluxModel.__repr__` to show it as
  '<vaxflux.VaxfluxModel ...>' like how a user imports it.
- Updated docstring examples in `VaxfluxModel` to account for the change
  above.

No major changes. Closes #117.