### PR TITLE
Add `.gitattributes`, fix `VaxfluxModel.sample`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Normalize all text files to use LF line endings
+*        text=auto eol=lf
+*.bat    text eol=crlf
+*.cmd    text eol=crlf
+
+# Treat jupyter notebooks as binary files
+*.ipynb  -text -diff -merge
+*.ipynb  linguist-generated

--- a/demos/vaxflux-model.ipynb
+++ b/demos/vaxflux-model.ipynb
@@ -159,7 +159,7 @@
     {
      "data": {
       "text/plain": [
-       "<vaxflux.VaxfluxModel object at 0x307da7cd0>"
+       "<vaxflux.VaxfluxModel object at 0x13a8c3450>"
       ]
      },
      "execution_count": 7,
@@ -436,8 +436,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "63187bdf",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "sample: 100%|██████████| 1500/1500 [00:14<00:00, 106.53it/s, 63 steps of size 6.84e-02. acc. prob=0.85]\n"
+     ]
+    }
+   ],
+   "source": [
+    "model.sample(warmup=500, samples=1000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cd9e0604",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/src/vaxflux/_vaxflux_model.py
+++ b/src/vaxflux/_vaxflux_model.py
@@ -399,9 +399,8 @@ class VaxfluxModel:
         warmup: int,
         samples: int,
         random_seed: int = 1,
-        *,
-        mcmc_args: dict[str, Any],
-        nuts_args: dict[str, Any],
+        mcmc_args: dict[str, Any] | None = None,
+        nuts_args: dict[str, Any] | None = None,
     ) -> None:
         """
         Sample from the model using MCMC with NUTS.
@@ -414,12 +413,14 @@ class VaxfluxModel:
             nuts_args: Additional arguments for the NUTS kernel.
 
         """
+        mcmc_args = mcmc_args or {}
+        nuts_args = nuts_args or {}
         self._pre_model()
         kernel = NUTS(self._model, **nuts_args)
-        mcmc = MCMC(kernel, **mcmc_args)
+        mcmc = MCMC(kernel, num_warmup=warmup, num_samples=samples, **mcmc_args)
         rng_key = key(random_seed)
         with numpyro.handlers.seed(numpyro.handlers.trace(self._model), rng_key):
-            mcmc.run(rng_key, num_warmup=warmup, num_samples=samples)
+            mcmc.run(rng_key)
 
     def _pre_model(self) -> None:
         """


### PR DESCRIPTION
- Added a `.gitattributes` file to normalize files, namely treating jupyter notebooks as binary files for diffing purposes.
- Fixed bug in `VaxfluxModel.sample` where warmup/samples were being provided to `MCMC.run` instead of `MCMC.__init__`.

No major changes.