### PR TITLE
Add duplicates check to `add_covariates`

### DIFF
--- a/src/vaxflux/_vaxflux_model.py
+++ b/src/vaxflux/_vaxflux_model.py
@@ -1,6 +1,7 @@
 __all__: list[str] = []
 
 import itertools
+from collections import Counter
 from itertools import chain
 from typing import Any, Literal, Self, cast
 
@@ -223,6 +224,7 @@ class VaxfluxModel:
         Raises:
             TypeError: If any argument is not a `Covariate` or a sequence of
                 `Covariate` objects.
+            ValueError: If duplicate parameter/covariate pairs are provided.
 
         Examples:
             >>> from vaxflux._covariates import PartiallyPooledGaussianCovariate
@@ -254,6 +256,21 @@ class VaxfluxModel:
 
         """  # noqa: E501
         covariates = _collect_args(args, Covariate, "Covariate")  # type: ignore[type-abstract]
+        existing_pairs = Counter(
+            (cov.parameter, cov.covariate) for cov in self._covariates
+        )
+        new_pairs = Counter((cov.parameter, cov.covariate) for cov in covariates)
+        duplicate_pairs = [
+            pair
+            for pair, count in new_pairs.items()
+            if count + existing_pairs.get(pair, 0) > 1
+        ]
+        if duplicate_pairs:
+            msg = (
+                "Duplicate covariate parameter/covariate pairs found: "
+                f"{duplicate_pairs}."
+            )
+            raise ValueError(msg)
         self._covariates.extend(covariates)
         return self
 

--- a/tests/vaxflux_model_class/test_add_covariates.py
+++ b/tests/vaxflux_model_class/test_add_covariates.py
@@ -1,0 +1,76 @@
+"""Unit tests for the `VaxfluxModel.add_covariates` method."""
+
+import pytest
+
+from vaxflux import (
+    Covariate,
+    LogisticCurve,
+    PartiallyPooledGaussianCovariate,
+    VaxfluxModel,
+)
+
+
+@pytest.mark.parametrize(
+    ("existing_covariates", "new_covariates", "match_pattern"),
+    [
+        (
+            None,
+            [
+                PartiallyPooledGaussianCovariate(
+                    parameter="m",
+                    covariate="age",
+                    mu=(0.5, 0.1),
+                    sigma=0.2,
+                ),
+                PartiallyPooledGaussianCovariate(
+                    parameter="m",
+                    covariate="age",
+                    mu=(0.6, 0.1),
+                    sigma=0.3,
+                ),
+            ],
+            r"\[\('m', 'age'\)\]\.$",
+        ),
+        (
+            [
+                PartiallyPooledGaussianCovariate(
+                    parameter="r",
+                    covariate="sex",
+                    mu=(0.5, 0.1),
+                    sigma=0.2,
+                ),
+            ],
+            [
+                PartiallyPooledGaussianCovariate(
+                    parameter="r",
+                    covariate="sex",
+                    mu=(0.6, 0.1),
+                    sigma=0.3,
+                ),
+            ],
+            r"\[\('r', 'sex'\)\]\.$",
+        ),
+    ],
+)
+def test_add_covariates_duplicate_pairs(
+    existing_covariates: list[Covariate] | None,
+    new_covariates: list[Covariate],
+    match_pattern: str,
+) -> None:
+    """
+    Adding duplicate covariate pairs raises a `ValueError`.
+
+    Args:
+        existing_covariates: Existing covariates to add to the model.
+        new_covariates: New covariates to add to the model.
+        match_pattern: Regex pattern to match in the ValueError message.
+
+    """
+    model = VaxfluxModel(curve=LogisticCurve())
+
+    if existing_covariates:
+        model.add_covariates(*existing_covariates)
+
+    match_prefix = r"^Duplicate covariate parameter/covariate pairs found: "
+    with pytest.raises(ValueError, match=match_prefix + match_pattern):
+        model.add_covariates(*new_covariates)


### PR DESCRIPTION
Added a check to `VaxfluxModel.add_covariates` to prevent duplicates. In this case checking for unique parameter+covariate is sufficient to check for duplicates. No major changes.

Closes #132.