### PR TITLE
Fix demos and equations display in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@ Removed:
 Fixed:
 
 - Corrected typo in the word "introduction" in the documentation navigation bar.
+- Fixed the display of equations in the documentation, see
+  [#123](https://github.com/ACCIDDA/vaxflux/issues/123).
+- Fixed the display of the demo notebooks in the documentation using
+  `mkdocs-jupyter` instead of converting notebooks to markdown files, see
+  [#146](https://github.com/ACCIDDA/vaxflux/issues/146).
 
 Security:
 

--- a/docs/model-details.md
+++ b/docs/model-details.md
@@ -54,12 +54,12 @@ drawn from a normal distribution, but `vaxflux` allows for any distribution to
 be used. The inflection point can be defined as:
 
 $$
-\begin{align}
+\begin{aligned}
 s^{\mathrm{season}}_{i}&\sim\mathcal{N}\left(\mu^{\mathrm{season}},\sigma^{\mathrm{season}^2}\right) \\
 s^{\mathrm{age}}_{i,j}&\sim\mathcal{N}\left(\boldsymbol{\mu}^{\mathrm{age}},\Sigma^{\mathrm{age}^2}\right) \\
 s^{\mathrm{density}}_{i,k}&\sim\mathcal{N}\left({\mu}^{\mathrm{density}},\sigma^{\mathrm{density}^2}\right) \\
 s_{i,j,k} &= s^{\mathrm{season}}_{i} + s^{\mathrm{age}}_{i,j} + s^{\mathrm{density}}_{i,k}
-\end{align}
+\end{aligned}
 $$
 
 Where $i$ is the season index, $j$ is the age category index, and $k$ is the
@@ -96,10 +96,10 @@ For each day in a season, $i$, we model the observed incidence of vaccinations
 on that day as:
 
 $$
-\begin{align}
+\begin{aligned}
 \varepsilon_i&\sim\mathrm{Exponential}\left(\epsilon^{-1}\right) \\
 I_{t,i}&\sim\mathrm{Gamma}\left(f(t+1\vert\theta_1,\dots,\theta_n)-f(t\vert\theta_1,\dots,\theta_n),\varepsilon_i\right)
-\end{align}
+\end{aligned}
 $$
 
 Where the gamma distribution is mean-variance parameterized, $I_{t,i}$ is the

--- a/justfile
+++ b/justfile
@@ -52,8 +52,6 @@ api-reference: venv
 demos: venv
     {{mkdir}} docs/demos/
     {{cp}} demos/*.ipynb docs/demos/
-    uv run jupyter nbconvert --to markdown docs/demos/*.ipynb
-    {{rm}} docs/demos/*.ipynb
 
 # Build complete documentation
 [group('docs')]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,8 @@ extra_css:
 plugins:
   - search
   - autorefs
+  - mkdocs-jupyter:
+      execute: false
   - mkdocstrings:
       handlers:
         python:
@@ -67,11 +69,11 @@ nav:
   - Getting Started: getting-started.md
   - Model Details: model-details.md
   - Demos:
-      - IDD Demo: demos/idd-demo.md
-      - Synthetic Data Daily: demos/synthetic-data-daily.md
-      - Synthetic Data: demos/synthetic-data.md
-      - Uptake Model: demos/uptake-model.md
-      - Vaxflux Model: demos/vaxflux-model.md
+      - IDD Demo: demos/idd-demo.ipynb
+      - Synthetic Data Daily: demos/synthetic-data-daily.ipynb
+      - Synthetic Data: demos/synthetic-data.ipynb
+      - Uptake Model: demos/uptake-model.ipynb
+      - Vaxflux Model: demos/vaxflux-model.ipynb
   - API Reference:
       - Vaxflux: api/vaxflux.md
       - Covariates: api/covariates.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,14 @@ dependencies = [
 [dependency-groups]
 dev = [
     "mike>=2.1.3",
-    "mkdocs>=1.6.1",
+    "mkdocs<1.6.0; python_version <= '3.12'",
+    "mkdocs>=1.6.0; python_version >= '3.13'",
     "mkdocs-autorefs>=1.4.3",
-    "mkdocs-material>=9.7.0",
-    "mkdocstrings[python]>=0.30.1",
+    "mkdocs-jupyter>=0.24.1",
+    "mkdocs-material<9.7.0; python_version <= '3.12'",
+    "mkdocs-material>=9.7.0; python_version >= '3.13'",
+    "mkdocstrings[python]<0.30.1; python_version <= '3.12'",
+    "mkdocstrings[python]>=0.30.1; python_version >= '3.13'",
     "mypy>=1.14.1",
     "pandas-stubs>=2.2.3.241126",
     "pytest>=8.3.2",

--- a/src/vaxflux/_covariates.py
+++ b/src/vaxflux/_covariates.py
@@ -70,11 +70,11 @@ class PartiallyPooledGaussianCovariate(Covariate):
     r"""
     Covariate model using a pooled Gaussian approach.
 
-    $$ \\mu_i \\sim \\mathrm{Normal}(\\mu_0, \\mu_1) $$
-
-    $$ \\sigma_i \\sim \\mathrm{Half}\\text{-}\\mathrm{Normal}(\\sigma) $$
-
-    $$ x_i \\sim \\mathrm{Normal}(\\mu_i, \\sigma_i) $$
+    $$ \begin{aligned}
+    \mu_i &\sim \mathrm{Normal}(\mu_0, \mu_1) \\\\
+    \sigma_i &\sim \mathrm{HalfNormal}(\sigma) \\\\
+    x_i &\sim \mathrm{Normal}(\mu_i, \sigma_i)
+    \end{aligned} $$
 
     Attributes:
         mu: A tuple representing the location and scale of the partially pooled mean.


### PR DESCRIPTION
- Fixed how the demo notebooks are displayed by making use of
  `mkdocs-jupyter` instead of manually converting notebooks to markdown
  files. Had to add constraints to mkdocs for python <=3.12.
- Fixed equation displays for the `PartiallyPooledGaussianCovariate` and
  removed equation numbering in the model details page.

Closes #123. Closes #146.