### PR TITLE
Add season only vaxflux model demo to docs site

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,7 @@ nav:
       - Synthetic Data: demos/synthetic-data.ipynb
       - Uptake Model: demos/uptake-model.ipynb
       - Vaxflux Model: demos/vaxflux-model.ipynb
+      - Season Only Vaxflux Model: demos/season-only-vaxflux-model.ipynb
   - API Reference:
       - Vaxflux: api/vaxflux.md
       - Covariates: api/covariates.md


### PR DESCRIPTION
Added the `demos/season-only-vaxflux-model.ipynb` demo notebook to the documentation site. No major changes.