### PR TITLE
Fix pandas categorical column warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,10 @@ Fixed:
 - Fixed the display of the demo notebooks in the documentation using
   `mkdocs-jupyter` instead of converting notebooks to markdown files, see
   [#146](https://github.com/ACCIDDA/vaxflux/issues/146).
+- Addressed warning from `pd.Categorical` call in private utility about non-null
+  values being given that might not be in the `categories`. The fix was moving
+  the validation of these values up before constructing the series. See
+  [#154](https://github.com/ACCIDDA/vaxflux/issues/154).
 
 Security:
 

--- a/src/vaxflux/_util.py
+++ b/src/vaxflux/_util.py
@@ -372,9 +372,7 @@ def _validate_and_format_observations(
             "The observations DataFrame is missing "
             f"required columns: {missing_columns}."
         )
-        raise ValueError(
-            msg,
-        )
+        raise ValueError(msg)
     observations = observations.copy()
     observations["season"] = observations["season"].astype(str)
     observations["value"] = pd.to_numeric(observations["value"])
@@ -382,36 +380,30 @@ def _validate_and_format_observations(
         msg = (
             "The observations DataFrame contains invalid values in the 'value' column."
         )
-        raise ValueError(
-            msg,
-        )
+        raise ValueError(msg)
     if observations["value"].lt(0).any():
         msg = (
             "The observations DataFrame contains negative values in the 'value' column."
         )
-        raise ValueError(
-            msg,
-        )
-    observations["type"] = pd.Categorical(
-        observations["type"].astype(str),
-        categories=_OBSERVATION_TYPE_CATEGORIES,
-    )
-    if observations["type"].isna().any():
+        raise ValueError(msg)
+    type_values = observations["type"].astype(str)
+    invalid_types = ~type_values.isin(_OBSERVATION_TYPE_CATEGORIES)
+    if invalid_types.any():
         msg = (
             "The observations DataFrame contains invalid values in the "
             f"'type' column, must be one of {_OBSERVATION_TYPE_CATEGORIES}."
         )
-        raise ValueError(
-            msg,
-        )
+        raise ValueError(msg)
+    observations["type"] = pd.Categorical(
+        type_values,
+        categories=_OBSERVATION_TYPE_CATEGORIES,
+    )
     if {"incidence"} != set(observations["type"].unique().tolist()):
         msg = (
             "Only 'incidence' data is supported, 'prevalence' and count equivalents "
             "are planned."
         )
-        raise NotImplementedError(
-            msg,
-        )
+        raise NotImplementedError(msg)
     for col in {"start_date", "end_date", "report_date"}.intersection(
         observation_columns,
     ):
@@ -428,9 +420,7 @@ def _validate_and_format_observations(
             "Observations with differing report dates were provided, "
             "nowcasting is not currently supported but planned."
         )
-        raise NotImplementedError(
-            msg,
-        )
+        raise NotImplementedError(msg)
     return observations
 
 


### PR DESCRIPTION
Fixed issue where `pd.Categorical` was raising a warning from `_validate_and_format_observations` when running the test suite. The fix was to check that the values are contained in the columns valid categories before calling `pd.Categorical`.

Closes #154.