### PR TITLE
Stop pop up plot windows from `just demo-test`

### DIFF
--- a/justfile
+++ b/justfile
@@ -98,7 +98,10 @@ demo-test:
     uv run jupyter nbconvert --to script demos/*.ipynb
     {{mv}} demos/*.py demos/scripts/
     echo "Running demo test scripts"
+    TMP=$(mktemp)
+    touch ${TMP}
     for file in demos/scripts/*.py; do
+        awk 'NR==4{print "import matplotlib; matplotlib.use(\"Agg\")"}1' ${file} > ${TMP} && mv ${TMP} ${file}
         echo "Running $file"
         time uv run python "$file"
     done

--- a/src/vaxflux/_vaxflux_model.py
+++ b/src/vaxflux/_vaxflux_model.py
@@ -389,7 +389,7 @@ class VaxfluxModel:
         if self._observations is None:
             msg = "No observations have been added to the model, nothing to observe."
             raise ValueError(msg)
-        if kind not in {"normal"}:
+        if kind != "normal":
             msg = f"Unsupported observation process kind: {kind}."
             raise ValueError(msg)
         if prevalence_penalty < 0:

--- a/tests/vaxflux_model_class/test__pre_model.py
+++ b/tests/vaxflux_model_class/test__pre_model.py
@@ -33,44 +33,46 @@ class DummyCurve(Curve):
     ("model_factory", "expected"),
     [
         (
-            lambda: VaxfluxModel(curve=DummyCurve())
-            .add_seasons(
-                SeasonRange(
-                    season="2023/2024",
-                    start_date=date(2023, 12, 1),
-                    end_date=date(2024, 3, 31),
-                ),
-                SeasonRange(
-                    season="2024/2025",
-                    start_date=date(2024, 12, 1),
-                    end_date=date(2025, 3, 31),
-                ),
-            )
-            .add_covariate_categories(
-                CovariateCategories(covariate="sex", categories=("female", "male"))
-            )
-            .add_covariates(
-                PartiallyPooledGaussianCovariate(
-                    parameter="m",
-                    covariate=None,
-                    mu_mu=0.0,
-                    mu_sigma=1.0,
-                    sigma=1.0,
-                ),
-                PartiallyPooledGaussianCovariate(
-                    parameter="m",
-                    covariate="sex",
-                    mu_mu=0.0,
-                    mu_sigma=1.0,
-                    sigma=1.0,
-                ),
-                PartiallyPooledGaussianCovariate(
-                    parameter="r",
-                    covariate=None,
-                    mu_mu=0.0,
-                    mu_sigma=1.0,
-                    sigma=1.0,
-                ),
+            lambda: (
+                VaxfluxModel(curve=DummyCurve())
+                .add_seasons(
+                    SeasonRange(
+                        season="2023/2024",
+                        start_date=date(2023, 12, 1),
+                        end_date=date(2024, 3, 31),
+                    ),
+                    SeasonRange(
+                        season="2024/2025",
+                        start_date=date(2024, 12, 1),
+                        end_date=date(2025, 3, 31),
+                    ),
+                )
+                .add_covariate_categories(
+                    CovariateCategories(covariate="sex", categories=("female", "male"))
+                )
+                .add_covariates(
+                    PartiallyPooledGaussianCovariate(
+                        parameter="m",
+                        covariate=None,
+                        mu_mu=0.0,
+                        mu_sigma=1.0,
+                        sigma=1.0,
+                    ),
+                    PartiallyPooledGaussianCovariate(
+                        parameter="m",
+                        covariate="sex",
+                        mu_mu=0.0,
+                        mu_sigma=1.0,
+                        sigma=1.0,
+                    ),
+                    PartiallyPooledGaussianCovariate(
+                        parameter="r",
+                        covariate=None,
+                        mu_mu=0.0,
+                        mu_sigma=1.0,
+                        sigma=1.0,
+                    ),
+                )
             ),
             {
                 "season_names": ["2023/2024", "2024/2025"],
@@ -87,22 +89,24 @@ class DummyCurve(Curve):
             },
         ),
         (
-            lambda: VaxfluxModel(curve=DummyCurve())
-            .add_seasons(
-                SeasonRange(
-                    season="2023/2024",
-                    start_date=date(2023, 12, 1),
-                    end_date=date(2024, 3, 31),
-                ),
-            )
-            .add_covariates(
-                PartiallyPooledGaussianCovariate(
-                    parameter="m",
-                    covariate=None,
-                    mu_mu=0.0,
-                    mu_sigma=1.0,
-                    sigma=1.0,
-                ),
+            lambda: (
+                VaxfluxModel(curve=DummyCurve())
+                .add_seasons(
+                    SeasonRange(
+                        season="2023/2024",
+                        start_date=date(2023, 12, 1),
+                        end_date=date(2024, 3, 31),
+                    ),
+                )
+                .add_covariates(
+                    PartiallyPooledGaussianCovariate(
+                        parameter="m",
+                        covariate=None,
+                        mu_mu=0.0,
+                        mu_sigma=1.0,
+                        sigma=1.0,
+                    ),
+                )
             ),
             {
                 "season_names": ["2023/2024"],


### PR DESCRIPTION
Inject a small piece of code at the top of the python scripts that are converted from the demo notebooks to suppress matplotlib from producing pop up plot windows. No major changes.