### PR TITLE
Streamline workflows and simplify local tooling

### DIFF
--- a/.github/actions/setup-just-and-uv/action.yaml
+++ b/.github/actions/setup-just-and-uv/action.yaml
@@ -1,0 +1,29 @@
+---
+name: 'setup-just-and-uv'
+description: 'Setup just and uv for use in CI workflows'
+
+inputs:
+  python-version:
+    description: 'Python version to install/configure via uv'
+    required: false
+    default: '3.12'
+  enable-cache:
+    description: 'Whether to enable uv caching'
+    required: false
+    default: 'true'
+  cache-dependency-glob:
+    description: 'Dependency files used for uv cache keying'
+    required: false
+    default: 'pyproject.toml'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'install just'
+      uses: 'extractions/setup-just@v3'
+    - name: 'setup uv'
+      uses: 'astral-sh/setup-uv@v7'
+      with:
+        enable-cache: '${{ inputs.enable-cache }}'
+        cache-dependency-glob: '${{ inputs.cache-dependency-glob }}'
+        python-version: '${{ inputs.python-version }}'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,29 +11,65 @@ permissions:
   contents: 'read'
 
 jobs:
-  ci:
-    name: 'ci'
+  docs:
+    name: 'docs'
     runs-on: 'ubuntu-latest'
     strategy:
       matrix:
         python-version:
-          - '3.11'
           - '3.12'
     steps:
       - name: 'checkout repository'
         uses: 'actions/checkout@v6'
-      - name: 'setup just'
-        uses: 'extractions/setup-just@v3'
-      - name: 'setup uv with python ${{ matrix.python-version }}'
-        uses: 'astral-sh/setup-uv@v7'
+      - name: 'setup just and uv'
+        uses: './.github/actions/setup-just-and-uv'
         with:
-          enable-cache: true
-          cache-dependency-glob: 'pyproject.toml'
           python-version: '${{ matrix.python-version }}'
-      - name: 'run ci'
-        run: 'just ci'
+      - name: 'build docs'
+        run: 'just docs'
         env:
           UV_PYTHON_VERSION: '${{ matrix.python-version }}'
+  quality:
+    name: 'quality'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'checkout repository'
+        uses: 'actions/checkout@v6'
+      - name: 'setup just and uv'
+        uses: './.github/actions/setup-just-and-uv'
+        with:
+          python-version: '3.12'
+      - name: 'run quality checks'
+        run: 'just quality'
+        env:
+          UV_PYTHON_VERSION: '3.12'
+  tests:
+    name: 'tests (${{ matrix.python-version }}, ${{ matrix.resolution }})'
+    needs:
+      - 'docs'
+      - 'quality'
+    runs-on: 'ubuntu-latest'
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - '3.11'
+          - '3.12'
+        resolution:
+          - 'highest'
+          - 'lowest-direct'
+    steps:
+      - name: 'checkout repository'
+        uses: 'actions/checkout@v6'
+      - name: 'setup just and uv'
+        uses: './.github/actions/setup-just-and-uv'
+        with:
+          python-version: '${{ matrix.python-version }}'
+      - name: 'run tests'
+        run: 'just ci-pytest'
+        env:
+          UV_PYTHON_VERSION: '${{ matrix.python-version }}'
+          UV_RESOLUTION: '${{ matrix.resolution }}'
   changelog:
     name: 'changelog'
     runs-on: 'ubuntu-latest'
@@ -55,25 +91,3 @@ jobs:
             echo "Error: Please update CHANGELOG.md"
             exit 1
           fi
-  docs:
-    name: 'docs'
-    runs-on: 'ubuntu-latest'
-    strategy:
-      matrix:
-        python-version:
-          - '3.12'
-    steps:
-      - name: 'checkout repository'
-        uses: 'actions/checkout@v6'
-      - name: 'setup just'
-        uses: 'extractions/setup-just@v3'
-      - name: 'setup uv with python ${{ matrix.python-version }}'
-        uses: 'astral-sh/setup-uv@v7'
-        with:
-          enable-cache: true
-          cache-dependency-glob: 'pyproject.toml'
-          python-version: '${{ matrix.python-version }}'
-      - name: 'build docs'
-        run: 'just docs'
-        env:
-          UV_PYTHON_VERSION: '${{ matrix.python-version }}'

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -28,13 +28,9 @@ jobs:
         uses: 'actions/checkout@v6'
         with:
           ref: 'main'
-      - name: 'setup just'
-        uses: 'extractions/setup-just@v3'
-      - name: 'setup uv with python ${{ matrix.python-version }}'
-        uses: 'astral-sh/setup-uv@v7'
+      - name: 'setup just and uv'
+        uses: './.github/actions/setup-just-and-uv'
         with:
-          enable-cache: true
-          cache-dependency-glob: 'pyproject.toml'
           python-version: '${{ matrix.python-version }}'
       - name: 'fetch gh-pages branch'
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -51,13 +51,9 @@ jobs:
     steps:
       - name: 'checkout repository'
         uses: 'actions/checkout@v6'
-      - name: 'setup just'
-        uses: 'extractions/setup-just@v3'
-      - name: 'setup uv'
-        uses: 'astral-sh/setup-uv@v6'
+      - name: 'setup just and uv'
+        uses: './.github/actions/setup-just-and-uv'
         with:
-          enable-cache: true
-          cache-dependency-glob: 'pyproject.toml'
           python-version: '${{ matrix.python-version }}'
       - name: 'yamllint check'
         run: 'just yamllint'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,15 +42,10 @@ jobs:
             echo "proceed=false" >> "${GITHUB_OUTPUT}"
             echo "Commit message does not start with vX.Y.Z; skipping release."
           fi
-      - name: 'setup just'
+      - name: 'setup just and uv'
         if: "${{ steps.check-release.outputs.proceed == 'true' }}"
-        uses: 'extractions/setup-just@v3'
-      - name: 'setup uv with python ${{ matrix.python-version }}'
-        if: "${{ steps.check-release.outputs.proceed == 'true' }}"
-        uses: 'astral-sh/setup-uv@v7'
+        uses: './.github/actions/setup-just-and-uv'
         with:
-          enable-cache: true
-          cache-dependency-glob: 'pyproject.toml'
           python-version: '${{ matrix.python-version }}'
       - name: 'run release'
         if: "${{ steps.check-release.outputs.proceed == 'true' }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ This document provides guidelines and instructions for contributing to
 
 ### Prerequisites
 
-- Python 3.10, 3.11, or 3.12.
+- Python 3.11 or 3.12.
 - [`uv`](https://docs.astral.sh/uv/) - Python package manager.
 - [`npm`](https://www.npmjs.com/) - Node package manager for auxiliary
   formatting/linting tools.
@@ -23,19 +23,22 @@ git clone git@github.com:ACCIDDA/vaxflux.git
 cd vaxflux
 ```
 
-2. Create a virtual environment and install dependencies:
+2. Install dependencies:
 
 ```shell
-uv sync --dev
+uv sync --all-extras
 ```
 
-This creates a `.venv` virtual environment and installs the package along with
-all development dependencies (mypy, pytest, ruff, mkdocs). If you need to create
-an environment with a specific python version you can also run:
+This installs the package along with development, documentation, and optional
+plotting dependencies used across local workflows. If you want to pin the
+environment to a specific supported Python version you can also run:
 
 ```shell
-uv sync --dev --python 3.12
+uv sync --all-extras --python 3.12
 ```
+
+Most commands in this repository are invoked through `uv run ...`, which will
+also create or update the local environment as needed.
 
 3. Verify your setup
 
@@ -47,8 +50,9 @@ This runs the default development checks:
 
 - `ruff format` - Format code.
 - `ruff check --fix` - Lint and auto-fix issues.
-- `pytest --doctest-modules` - Run tests including doctests.
 - `mypy --strict` - Type check with strict settings.
+- `pytest --doctest-modules --cov=src/vaxflux --cov-report=term-missing` - Run
+  tests including doctests with a local coverage report.
 - `npm run cspell` - Spell check linting.
 - `npm run prettier:fix` - Formatting for JSON/markdown/YAML files.
 - `yamllint --strict` - Lint YAML files.
@@ -103,9 +107,10 @@ tests/
 
 ### Running Tests
 
-Running all tests is a part of `just` and `just dev`. If you instead want to
-only run the unit tests you can run `just pytest`. For more advanced running
-please use `pytest` directly:
+Running all tests is a part of `just` and `just dev`. If you instead want to run
+the Python test suite with a coverage report you can run `just cov`. Coverage is
+currently for local visibility only; CI does not enforce a coverage threshold.
+For more advanced invocations, please use `pytest` directly:
 
 ```shell
 uv run pytest tests/{module}/ -v                    # Run all tests in a module
@@ -120,7 +125,7 @@ documentation.
 
 - Any public API should have unit tests that reaffirm the documentation's
   description.
-- If possible unit tests should use `@pytest.mark.parameterize` for generality
+- If possible unit tests should use `@pytest.mark.parametrize` for generality
   and ease of adding new test cases.
 - Use descriptive test names that explain what is being tested. In the case of
   testing exceptions also the type of exception.
@@ -158,14 +163,19 @@ build the documentation and start a local server at
 
 - `ruff format --check` - Verify code formatting (no auto-fix).
 - `ruff check --no-fix` - Lint without modifications.
-- `pytest --doctest-modules` - Run test suite.
 - `mypy --strict` - Type checking.
+- `pytest --doctest-modules --exitfirst` - Run the test suite in a CI-style
+  configuration.
 
-In addition you will also want to make sure that `just lint` is successful.
+In addition, you should run:
+
+- `just docs` - Build the MkDocs documentation as CI does.
+- `just lint` - Run `cspell`, `prettier`, and `yamllint`.
 
 2. Update documentation if your changes affect user-facing functionality or add
    features that require usage guides. Also update the `CHANGELOG.md` with a
-   description of your changes.
+   description of your changes. Commits containing `no major changes` will skip
+   the changelog check in CI.
 
 3. Add tests for new functionality or bug fixes. Particularly for bug fixes, the
    test should be written before the fix and fail without the fix present.
@@ -186,7 +196,13 @@ In addition you will also want to make sure that `just lint` is successful.
 
 ### Pull Request Requirements
 
-- PRs are tested against Python 3.10, 3.11, and 3.12 using `just ci`.
+- PR CI runs:
+- `docs` on Python 3.12.
+- `quality` on Python 3.12.
+- `tests` on Python 3.11 and 3.12 with both `highest` and `lowest-direct`
+  dependency resolution.
+- `changelog` on pull requests.
+- A separate lint workflow runs `prettier`, `cspell`, and `yamllint`.
 - Documentation must build successfully with `just docs`.
 - Linting must also be successful.
 - Branches must be up to date against `main` before merging and have a linear

--- a/cspell.json
+++ b/cspell.json
@@ -13,7 +13,6 @@
   "words": [
     "accidda",
     "arviz",
-    "blackjax",
     "boldsymbol",
     "chol",
     "covariate",
@@ -24,6 +23,7 @@
     "doctest",
     "doctests",
     "dtype",
+    "exitfirst",
     "expit",
     "figsize",
     "fontsize",

--- a/justfile
+++ b/justfile
@@ -9,7 +9,7 @@ mkdir := "mkdir -vp"
 default: dev lint docs
 
 # Run all development checks
-dev: format check mypy pytest
+dev: format check mypy cov
 
 # Run all linting checks
 lint: cspell prettier yamllint
@@ -28,18 +28,17 @@ clean-docs:
 [unix]
 [group('clean')]
 clean: clean-docs
-    {{rmdir}} .mypy_cache
-    {{rmdir}} .pytest_cache
-    {{rmdir}} .ruff_cache
-    {{rmdir}} .venv
-    {{rmdir}} src/vaxflux/__pycache__
-    {{rmdir}} src/vaxflux.egg-info
+    {{rmdir}} .*cache/
+    {{rmdir}} .venv/
+    {{rmdir}} node_modules/
+    {{rmdir}} src/vaxflux/__pycache__/
+    {{rmdir}} src/vaxflux.egg-info/
     {{rm}} uv.lock
 
 # Generate API reference documentation
 [unix]
 [group('docs')]
-reference: venv
+reference:
     {{cp}} CHANGELOG.md docs/changelog.md
     {{cp}} CONTRIBUTING.md docs/contributing.md
     {{cp}} README.md docs/index.md
@@ -47,44 +46,39 @@ reference: venv
 # Generate demo documentation
 [unix]
 [group('docs')]
-demos: venv
+demos:
     {{mkdir}} docs/demos/
     {{cp}} demos/*.ipynb docs/demos/
 
 # Build complete documentation
 [group('docs')]
-docs: venv reference demos
+docs: reference demos
     uv run mkdocs build --verbose --strict
 
 # Serve documentation locally
 [group('docs')]
-serve: venv docs
+serve: docs
     uv run mkdocs serve
-
-# Setup the venv
-[group('dev')]
-venv:
-    uv sync --all-extras
 
 # Format code with ruff
 [group('dev')]
-format: venv
+format:
     uv run ruff format
 
 # Check and fix code issues with ruff
 [group('dev')]
-check: venv
+check:
     uv run ruff check --fix --unsafe-fixes
 
 # Run mypy type checking
 [group('dev')]
-mypy: venv
+mypy:
     uv run mypy --strict .
 
-# Run pytest tests
+# Run pytest with a coverage report
 [group('dev')]
-pytest: venv
-    uv run pytest --doctest-modules
+cov:
+    uv run pytest --doctest-modules --cov=src/vaxflux --cov-report=term-missing
 
 # Run demo tests
 [unix]
@@ -109,11 +103,27 @@ demo-test:
 
 # Run CI checks (non-interactive)
 [group('ci')]
-ci: venv
+ci: quality ci-pytest
+
+# Run CI quality checks
+[group('ci')]
+quality: ci-ruff ci-mypy
+
+# Run CI ruff formatting and linting checks
+[group('ci')]
+ci-ruff:
     uv run ruff format --check
     uv run ruff check --no-fix
+
+# Run CI mypy type checking
+[group('ci')]
+ci-mypy:
     uv run mypy --strict .
-    uv run pytest --doctest-modules --exitfirst
+
+# Run CI pytest checks using the resolution from `UV_RESOLUTION`
+[group('ci')]
+ci-pytest:
+    uv run --isolated --group dev --extra plot pytest --doctest-modules --exitfirst
 
 # Install npm dependencies
 [group('lint')]
@@ -141,12 +151,12 @@ cspell: npm-install
 
 # Run yamllint on YAML files
 [group('lint')]
-yamllint: venv
+yamllint:
     uv run yamllint --strict .
 
 # Create a GitHub release
 [confirm]
 [unix]
 [group('release')]
-release +FLAGS='': venv
+release +FLAGS='':
     uv run python scripts/release.py {{FLAGS}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -940,9 +940,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ dependencies = [
     "pandas>=2.2.2",
     "xarray>=2024.7.0",
     "pydantic>=2.10.6",
-    "blackjax>=1.2.5",
     "jax>=0.6.2",
     "numpyro>=0.19.0",
 ]
@@ -32,6 +31,7 @@ dev = [
     "mypy>=1.14.1",
     "pandas-stubs>=2.2.3.241126",
     "pytest>=8.3.2",
+    "pytest-cov>=6.1.1",
     "ruamel-yaml>=0.18.16",
     "ruff>=0.9.4",
     "scipy-stubs>=1.15.1.0",


### PR DESCRIPTION
- Expand `just clean` to remove additional generated artifacts.
- Refresh `npm` dependencies via `npm audit fix` (`flatted` 3.3.3 -> 3.4.2).
- Remove the unused `blackjax` dependency.
- Add a local composite action for shared `just` + `uv` setup.
- Simplify the `justfile` by removing the `venv` recipe.
- Add `pytest-cov` and a local `just cov` command for coverage checks.
- Split CI into separate quality and test jobs.
- Add test matrix coverage for Python versions and `uv` resolution modes.

No major changes.