### PR TITLE
Add `VaxfluxModel/VaxfluxObservations.from_csv`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Added:
   [#135](https://github.com/ACCIDDA/vaxflux/issues/135).
 - Added `VaxfluxObservations` container class for observations, see
   [#160](https://github.com/ACCIDDA/vaxflux/issues/160).
+- Added ability to easily construct an observations instance, with
+  `VaxfluxObservations.from_csv`, as well as a default model, with
+  `VaxfluxModel.from_csv`, see
+  [#112](https://github.com/ACCIDDA/vaxflux/issues/112).
 
 Changed:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,9 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.pytest.ini_options]
+addopts = [
+    "--import-mode=importlib",
+]
 testpaths = [
     "src/vaxflux/",
     "tests/",
@@ -110,6 +113,8 @@ max-args = 8  # Default is 5
 [tool.mypy]
 plugins = ["numpy.typing.mypy_plugin"]
 exclude = "demos/*"
+explicit_package_bases = true
+mypy_path = "$MYPY_CONFIG_FILE_DIR/src"
 
 [[tool.mypy.overrides]]
 module = ["numpyro.*"]

--- a/src/vaxflux/_vaxflux_model.py
+++ b/src/vaxflux/_vaxflux_model.py
@@ -15,8 +15,8 @@ from numpyro.infer import MCMC, NUTS, Predictive
 
 from vaxflux._covariate_categories import CovariateCategories
 from vaxflux._covariate_index_info import CovariateIndexInfo
-from vaxflux._covariates import Covariate
-from vaxflux._curves import Curve
+from vaxflux._covariates import Covariate, SeasonVaryingPartiallyPooledGaussianCovariate
+from vaxflux._curves import Curve, LogisticCurve
 from vaxflux._dates import (
     DateRange,
     SeasonRange,
@@ -114,6 +114,78 @@ class VaxfluxModel:
             A string representation of the `VaxfluxModel` instance.
         """
         return f"<vaxflux.VaxfluxModel object at {hex(id(self))}>"
+
+    @classmethod
+    def from_csv(cls, *args: Any, **kwargs: Any) -> Self:
+        """
+        Construct a default model from observations stored in a CSV file.
+
+        The CSV is read with `VaxfluxObservations.from_csv`, then used to build a
+        model with:
+
+        - a default `LogisticCurve`,
+        - inferred seasons and dates from the observations,
+        - one `CovariateCategories` entry per observation covariate using the full
+          sorted list of observed levels,
+        - one `SeasonVaryingPartiallyPooledGaussianCovariate` per
+          curve-parameter/covariate pair with weak default hyperparameters
+          (`mu_mu=0.0`, `mu_sigma=1.0`, `sigma=1.0`),
+        - no interventions or implementations,
+        - a `"normal"` observation process with `noise=0.001`.
+
+        Args:
+            *args: Positional arguments forwarded to
+                `VaxfluxObservations.from_csv`.
+            **kwargs: Keyword arguments forwarded to
+                `VaxfluxObservations.from_csv`.
+
+        Returns:
+            A configured `VaxfluxModel` instance.
+
+        """
+        observations = VaxfluxObservations.from_csv(*args, **kwargs)
+        model = cls(curve=LogisticCurve())
+
+        season_ranges: list[SeasonRange] = _infer_ranges_from_observations(
+            observations.data, [], "season"
+        )
+        if season_ranges:
+            model.add_seasons(season_ranges)
+
+        date_ranges: list[DateRange] = _infer_ranges_from_observations(
+            observations.data, [], "date"
+        )
+        if date_ranges:
+            model.add_dates(date_ranges)
+
+        covariate_categories = [
+            CovariateCategories(
+                covariate=covariate_name,
+                categories=tuple(
+                    sorted(observations.data[covariate_name].astype(str).unique())
+                ),
+            )
+            for covariate_name in observations.covariate_columns
+        ]
+        if covariate_categories:
+            model.add_covariate_categories(covariate_categories)
+            model.add_covariates(
+                [
+                    SeasonVaryingPartiallyPooledGaussianCovariate(
+                        parameter=parameter,
+                        covariate=covariate_category.covariate,
+                        mu_mu=0.0,
+                        mu_sigma=1.0,
+                        sigma=1.0,
+                    )
+                    for parameter in model._curve.parameters
+                    for covariate_category in covariate_categories
+                ]
+            )
+
+        return model.add_observations(observations).add_observation_process(
+            kind="normal", noise=0.001
+        )
 
     def add_seasons(self, *args: SeasonRange | list[SeasonRange]) -> Self:
         """

--- a/src/vaxflux/_vaxflux_observations.py
+++ b/src/vaxflux/_vaxflux_observations.py
@@ -1,4 +1,4 @@
-from typing import Final
+from typing import Any, Final
 
 import pandas as pd
 from pandas.api.types import is_datetime64_any_dtype
@@ -93,6 +93,34 @@ class VaxfluxObservations:
         if isinstance(data, VaxfluxObservations):
             return data
         return cls(data)
+
+    @classmethod
+    def from_csv(cls, *args: Any, **kwargs: Any) -> "VaxfluxObservations":
+        """
+        Construct a `VaxfluxObservations` by reading a CSV with pandas.
+
+        This is a thin wrapper around `pandas.read_csv`; all positional and keyword
+        arguments are forwarded directly to that function before the resulting
+        DataFrame is validated and wrapped.
+
+        Args:
+            *args: Positional arguments forwarded to `pandas.read_csv`.
+            **kwargs: Keyword arguments forwarded to `pandas.read_csv`.
+
+        Returns:
+            A validated `VaxfluxObservations` instance.
+
+        Raises:
+            Exception: Propagates any exception raised by `pandas.read_csv`.
+            ValueError: If the resulting DataFrame is empty or missing required
+                columns.
+            ValueError: If the `value` column contains NaN or negative values.
+            ValueError: If the `type` column contains unsupported values.
+            NotImplementedError: If prevalence observations are provided.
+            NotImplementedError: If observations with differing report dates are
+                provided.
+        """
+        return cls.from_dataframe(pd.read_csv(*args, **kwargs))
 
     @property
     def data(self) -> pd.DataFrame:

--- a/tests/vaxflux_model_class/test_from_csv.py
+++ b/tests/vaxflux_model_class/test_from_csv.py
@@ -1,0 +1,85 @@
+"""Unit tests for `VaxfluxModel.from_csv`."""
+
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+
+from vaxflux import LogisticCurve, SeasonVaryingPartiallyPooledGaussianCovariate
+from vaxflux._vaxflux_model import VaxfluxModel
+from vaxflux._vaxflux_observations import VaxfluxObservations
+
+
+def test_from_csv_builds_default_model_from_observations(tmp_path: Path) -> None:
+    """`from_csv` builds the requested default model configuration."""
+    csv_path = tmp_path / "observations.psv"
+    pd.DataFrame(
+        data={
+            "season": ["2024/2025", "2023/2024", "2023/2024"],
+            "start_date": ["2024-10-01", "2023-10-01", "2023-10-08"],
+            "end_date": ["2024-10-07", "2023-10-07", "2023-10-14"],
+            "type": ["incidence", "incidence", "incidence"],
+            "value": [0.3, 0.1, 0.2],
+            "age": ["50+", "18-49", "50+"],
+            "region": ["west", "west", "east"],
+        }
+    ).to_csv(csv_path, sep="|", index=False)
+
+    model = VaxfluxModel.from_csv(csv_path, sep="|")
+
+    assert isinstance(model._curve, LogisticCurve)
+    assert isinstance(model._observations, VaxfluxObservations)
+    assert model._interventions == []
+    assert model._implementations == []
+    assert model._observation_process_kind == "normal"
+    assert model._observation_process_noise == 0.001
+    assert [
+        (season.season, season.start_date, season.end_date) for season in model._seasons
+    ] == [
+        ("2023/2024", date(2023, 10, 1), date(2023, 10, 14)),
+        ("2024/2025", date(2024, 10, 1), date(2024, 10, 7)),
+    ]
+    assert [
+        (
+            date_range.season,
+            date_range.start_date,
+            date_range.end_date,
+            date_range.report_date,
+        )
+        for date_range in model._dates
+    ] == [
+        ("2023/2024", date(2023, 10, 1), date(2023, 10, 7), date(2023, 10, 7)),
+        ("2023/2024", date(2023, 10, 8), date(2023, 10, 14), date(2023, 10, 14)),
+        ("2024/2025", date(2024, 10, 1), date(2024, 10, 7), date(2024, 10, 7)),
+    ]
+    assert {
+        categories.covariate: categories.categories
+        for categories in model._covariate_categories
+    } == {
+        "age": ("18-49", "50+"),
+        "region": ("east", "west"),
+    }
+    assert len(model._covariates) == len(model._curve.parameters) * 2
+    assert all(
+        isinstance(covariate, SeasonVaryingPartiallyPooledGaussianCovariate)
+        for covariate in model._covariates
+    )
+    typed_covariates = [
+        covariate
+        for covariate in model._covariates
+        if isinstance(covariate, SeasonVaryingPartiallyPooledGaussianCovariate)
+    ]
+    assert len(typed_covariates) == len(model._covariates)
+    assert {
+        (covariate.parameter, covariate.covariate) for covariate in model._covariates
+    } == {
+        ("m", "age"),
+        ("r", "age"),
+        ("s", "age"),
+        ("m", "region"),
+        ("r", "region"),
+        ("s", "region"),
+    }
+    assert all(covariate.mu_mu == 0.0 for covariate in typed_covariates)
+    assert all(covariate.mu_sigma == 1.0 for covariate in typed_covariates)
+    assert all(covariate.sigma == 1.0 for covariate in typed_covariates)

--- a/tests/vaxflux_observations_class/test_from_csv.py
+++ b/tests/vaxflux_observations_class/test_from_csv.py
@@ -1,0 +1,32 @@
+"""Unit tests for `VaxfluxObservations.from_csv`."""
+
+from pathlib import Path
+
+import pandas as pd
+from pandas.api.types import is_datetime64_any_dtype
+
+from vaxflux._vaxflux_observations import VaxfluxObservations
+
+
+def test_from_csv_wraps_pandas_read_csv_and_forwards_args(tmp_path: Path) -> None:
+    """`from_csv` forwards arguments to `pandas.read_csv` before validation."""
+    csv_path = tmp_path / "observations.psv"
+    pd.DataFrame(
+        data={
+            "season": ["2023/2024", "2023/2024"],
+            "start_date": ["2023-10-01", "2023-10-08"],
+            "end_date": ["2023-10-07", "2023-10-14"],
+            "type": ["incidence", "incidence"],
+            "value": [0.1, 0.2],
+            "region": ["west", "east"],
+        }
+    ).to_csv(csv_path, sep="|", index=False)
+
+    observations = VaxfluxObservations.from_csv(csv_path, sep="|")
+
+    assert isinstance(observations, VaxfluxObservations)
+    assert observations.covariate_columns == ["region"]
+    assert is_datetime64_any_dtype(observations.data["start_date"])
+    assert is_datetime64_any_dtype(observations.data["end_date"])
+    assert is_datetime64_any_dtype(observations.data["report_date"])
+    assert observations.data["value"].tolist() == [0.1, 0.2]


### PR DESCRIPTION
Added `from_csv` classmethods to `VaxfluxModel` and `VaxfluxObservations` that will construct a default model from a file and read observations from a file, respectively.

Closes #112.