### PR TITLE
Fix documentation aliases

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -85,7 +85,7 @@ jobs:
       - name: 'Deploy to GitHub Pages'
         run: |
           uv run mike set-default latest
-          if [ "${DEPLOY_MODE}" = "release" ] || [[ $VERSION == 0* ]]; then
+          if [ "${DEPLOY_MODE}" = "release" ]; then
             ALIAS=latest
           else
             ALIAS=dev


### PR DESCRIPTION
Corrected issue where 'latest' was pointing to the in development version of the documentation and 'dev' was not utilized. Now 'latest' will point to the last released version and 'dev' will point to the in development version.

No major changes. Closes #202.