### PR TITLE
Upgrade GitHub action dependencies

### DIFF
--- a/.github/actions/setup-just-and-uv/action.yaml
+++ b/.github/actions/setup-just-and-uv/action.yaml
@@ -20,9 +20,9 @@ runs:
   using: 'composite'
   steps:
     - name: 'install just'
-      uses: 'extractions/setup-just@v3'
+      uses: 'extractions/setup-just@v4'
     - name: 'setup uv'
-      uses: 'astral-sh/setup-uv@v7'
+      uses: 'astral-sh/setup-uv@v8.0.0'
       with:
         enable-cache: '${{ inputs.enable-cache }}'
         cache-dependency-glob: '${{ inputs.cache-dependency-glob }}'

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: 'checkout repository'
         uses: 'actions/checkout@v6'
       - name: 'setup just'
-        uses: 'extractions/setup-just@v3'
+        uses: 'extractions/setup-just@v4'
       - name: 'setup node'
         uses: 'actions/setup-node@v6'
         with:
@@ -33,7 +33,7 @@ jobs:
       - name: 'checkout repository'
         uses: 'actions/checkout@v6'
       - name: 'setup just'
-        uses: 'extractions/setup-just@v3'
+        uses: 'extractions/setup-just@v4'
       - name: 'setup node'
         uses: 'actions/setup-node@v6'
         with:


### PR DESCRIPTION
Upgraded `extractions/setup-just` from v3 to v4 and `astral-sh/setup-uv` from v7 to v8.0.0. No major changes. Closes #201.