### PR TITLE
Fix dependabot syntax

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,6 +8,7 @@ updates:
     cooldown:
       default-days: 14
     commit-message:
+      prefix: 'deps'
       include: 'scope'
     labels:
       - 'dependency'
@@ -18,6 +19,7 @@ updates:
     cooldown:
       default-days: 14
     commit-message:
+      prefix: 'deps'
       include: 'scope'
     labels:
       - 'dependency'
@@ -28,6 +30,7 @@ updates:
     cooldown:
       default-days: 14
     commit-message:
+      prefix: 'deps'
       include: 'scope'
     labels:
       - 'dependency'


### PR DESCRIPTION
Making use of `include: 'scope'` requires a prefix, so added `prefix: 'deps'`. No major changes.