### PR TITLE
Skip changelog check for dependabot

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,6 +100,9 @@ jobs:
           UV_PYTHON_VERSION: '${{ matrix.python-version }}'
   changelog:
     name: 'changelog'
+    if:
+      ${{ github.event_name != 'pull_request' ||
+      github.event.pull_request.user.login != 'dependabot[bot]' }}
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'checkout repository'


### PR DESCRIPTION
Skip running the changelog check for PRs opened by @dependabot[bot].

No major changes.