### PR TITLE
Update dependabot to group by semver

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,6 +7,22 @@ updates:
       interval: 'weekly'
     cooldown:
       default-days: 14
+    groups:
+      patch:
+        patterns:
+          - '*'
+        update-types:
+          - 'patch'
+      minor:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+      major:
+        patterns:
+          - '*'
+        update-types:
+          - 'major'
     commit-message:
       prefix: 'deps'
       include: 'scope'
@@ -18,6 +34,22 @@ updates:
       interval: 'weekly'
     cooldown:
       default-days: 14
+    groups:
+      patch:
+        patterns:
+          - '*'
+        update-types:
+          - 'patch'
+      minor:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+      major:
+        patterns:
+          - '*'
+        update-types:
+          - 'major'
     commit-message:
       prefix: 'deps'
       include: 'scope'
@@ -29,6 +61,22 @@ updates:
       interval: 'weekly'
     cooldown:
       default-days: 14
+    groups:
+      patch:
+        patterns:
+          - '*'
+        update-types:
+          - 'patch'
+      minor:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+      major:
+        patterns:
+          - '*'
+        update-types:
+          - 'major'
     commit-message:
       prefix: 'deps'
       include: 'scope'


### PR DESCRIPTION
Updated the `.github/dependabot.yaml` configuration to group dependency update PRs by their semver update to lower the number of PRs.

No major changes.